### PR TITLE
Making checks pass

### DIFF
--- a/docs_src/tutorial/fastapi/delete/tutorial001.py
+++ b/docs_src/tutorial/fastapi/delete/tutorial001.py
@@ -79,7 +79,7 @@ def update_hero(hero_id: int, hero: HeroUpdate):
         db_hero = session.get(Hero, hero_id)
         if not db_hero:
             raise HTTPException(status_code=404, detail="Hero not found")
-        hero_data = hero.dict(exclude_unset=True)
+        hero_data = hero.model_dump(exclude_unset=True)
         for key, value in hero_data.items():
             setattr(db_hero, key, value)
         session.add(db_hero)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.7"
 SQLAlchemy = ">=2.0.0,<=2.0.11"
-pydantic = "^2.1.1"
+pydantic = { version = ">=2.1.1,<=2.4", extras = ["email"] }
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.0.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ autoflake = "^1.4"
 isort = "^5.9.3"
 async_generator = {version = "*", python = "~3.7"}
 async-exit-stack = {version = "*", python = "~3.7"}
+importlib-metadata = { version = "*", python = ">3.7" }
 httpx = "^0.24.1"
 
 [build-system]

--- a/sqlmodel/ext/asyncio/session.py
+++ b/sqlmodel/ext/asyncio/session.py
@@ -1,9 +1,11 @@
-from typing import Any, Mapping, Optional, Sequence, TypeVar, Union
+from typing import Any, Dict, Mapping, Optional, Sequence, Type, TypeVar, Union
 
 from sqlalchemy import util
 from sqlalchemy.ext.asyncio import AsyncSession as _AsyncSession
 from sqlalchemy.ext.asyncio import engine
 from sqlalchemy.ext.asyncio.engine import AsyncConnection, AsyncEngine
+from sqlalchemy.orm import Mapper
+from sqlalchemy.sql.expression import TableClause
 from sqlalchemy.util.concurrency import greenlet_spawn
 from sqlmodel.sql.base import Executable
 
@@ -14,13 +16,18 @@ from ...sql.expression import Select
 _T = TypeVar("_T")
 
 
+BindsType = Dict[
+    Union[Type[Any], Mapper[Any], TableClause, str], Union[AsyncEngine, AsyncConnection]
+]
+
+
 class AsyncSession(_AsyncSession):
     sync_session: Session
 
     def __init__(
         self,
         bind: Optional[Union[AsyncConnection, AsyncEngine]] = None,
-        binds: Optional[Mapping[object, Union[AsyncConnection, AsyncEngine]]] = None,
+        binds: Optional[BindsType] = None,
         **kw: Any,
     ):
         # All the same code of the original AsyncSession

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -596,6 +596,10 @@ class SQLModel(BaseModel, metaclass=SQLModelMetaclass, registry=default_registry
         # in the Pydantic model so that when SQLAlchemy sets attributes that are
         # added (e.g. when querying from DB) to the __fields_set__, this already exists
         object.__setattr__(new_object, "__pydantic_fields_set__", set())
+        if not hasattr(new_object, "__pydantic_extra__"):
+            object.__setattr__(new_object, "__pydantic_extra__", None)
+        if not hasattr(new_object, "__pydantic_private__"):
+            object.__setattr__(new_object, "__pydantic_private__", None)
         return new_object
 
     def __init__(__pydantic_self__, **data: Any) -> None:

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -666,14 +666,15 @@ def _is_field_noneable(field: FieldInfo) -> bool:
         return field.nullable
     if not field.is_required():
         default = getattr(field, "original_default", field.default)
+        if default is PydanticUndefined:
+            return False
         if field.annotation is None or field.annotation is NoneType:
             return True
         if _is_optional_or_union(field.annotation):
             for base in get_args(field.annotation):
                 if base is NoneType:
                     return True
-        if default is PydanticUndefined:
-            return False
+
         return False
     return False
 

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ipaddress
 import sys
+import types
 import uuid
 import weakref
 from datetime import date, datetime, time, timedelta
@@ -26,7 +27,6 @@ from typing import (
     Union,
     cast,
 )
-import types
 
 import pydantic
 from pydantic import BaseModel
@@ -43,10 +43,9 @@ from sqlalchemy.orm.attributes import set_attribute
 from sqlalchemy.orm.decl_api import DeclarativeMeta
 from sqlalchemy.orm.instrumentation import is_instrumented
 from sqlalchemy.orm.properties import MappedColumn
-from sqlalchemy.sql.schema import MetaData, DefaultClause
-from sqlalchemy.sql.sqltypes import LargeBinary, Time
 from sqlalchemy.sql import false, true
-
+from sqlalchemy.sql.schema import DefaultClause, MetaData
+from sqlalchemy.sql.sqltypes import LargeBinary, Time
 
 from .sql.sqltypes import GUID, AutoString
 from .typing import SQLModelConfig

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -524,6 +524,8 @@ def get_column_from_field(field: FieldInfo) -> Column:  # type: ignore
         return sa_column
     if isinstance(sa_column, MappedColumn):
         return sa_column.column
+    if isinstance(sa_column, types.FunctionType):
+        return sa_column()
     sa_type = get_sqlalchemy_type(field)
     primary_key = getattr(field, "primary_key", False)
     index = getattr(field, "index", PydanticUndefined)

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -61,6 +61,9 @@ def __dataclass_transform__(
 
 
 class FieldInfo(PydanticFieldInfo):
+
+    nullable: Union[bool, PydanticUndefinedType]
+
     def __init__(self, default: Any = PydanticUndefined, **kwargs: Any) -> None:
         primary_key = kwargs.pop("primary_key", False)
         nullable = kwargs.pop("nullable", PydanticUndefined)
@@ -587,7 +590,7 @@ class SQLModel(BaseModel, metaclass=SQLModelMetaclass, registry=default_registry
 
 
 def _is_field_noneable(field: FieldInfo) -> bool:
-    if getattr(field, "nullable", PydanticUndefined) is not PydanticUndefined:
+    if not isinstance(field.nullable, PydanticUndefinedType):
         return field.nullable
     if not field.is_required():
         default = getattr(field, "original_default", field.default)

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -448,7 +448,7 @@ def _is_optional_or_union(type_: Optional[type]) -> bool:
 
 
 def get_sqlalchemy_type(field: FieldInfo) -> Any:
-    type_: Optional[type] = field.annotation
+    type_: Optional[type] | _AnnotatedAlias = field.annotation
 
     # Resolve Optional/Union fields
 
@@ -473,7 +473,7 @@ def get_sqlalchemy_type(field: FieldInfo) -> Any:
         if type2 is pydantic.AnyUrl:
             meta = get_args(type_)[1]
             return AutoString(length=meta.max_length)
-    elif org_type is pydantic.AnyUrl:
+    elif org_type is pydantic.AnyUrl and type(type_) is _AnnotatedAlias:
         return AutoString(type_.__metadata__[0].max_length)
 
     # The 3rd is PydanticGeneralMetadata

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -666,9 +666,7 @@ def _is_field_noneable(field: FieldInfo) -> bool:
         return field.nullable
     if not field.is_required():
         default = getattr(field, "original_default", field.default)
-        if default is None:
-            return True
-        elif default is PydanticUndefined:
+        if default is PydanticUndefined:
             return False
         if field.annotation is None or field.annotation is NoneType:
             return True

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -461,8 +461,11 @@ def get_sqlalchemy_type(field: FieldInfo) -> Any:
     # UrlConstraints(max_length=512,
     # allowed_schemes=['smb', 'ftp', 'file']) ]
     if type_ is pydantic.AnyUrl:
-        meta = field.metadata[0]
-        return AutoString(length=meta.max_length)
+        if field.metadata:
+            meta = field.metadata[0]
+            return AutoString(length=meta.max_length)
+        else:
+            return AutoString
 
     org_type = get_origin(type_)
     if org_type is Annotated:

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -668,7 +668,7 @@ def _is_field_noneable(field: FieldInfo) -> bool:
         default = getattr(field, "original_default", field.default)
         if default is None:
             return True
-        elif default is not PydanticUndefined:
+        elif default is PydanticUndefined:
             return False
         if field.annotation is None or field.annotation is NoneType:
             return True

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -29,7 +29,8 @@ from typing import (
 )
 
 import pydantic
-from pydantic import BaseModel
+from annotated_types import MaxLen
+from pydantic import BaseModel, EmailStr, ImportString, NameEmail
 from pydantic._internal._fields import PydanticGeneralMetadata
 from pydantic._internal._model_construction import ModelMetaclass
 from pydantic._internal._repr import Representation
@@ -480,7 +481,7 @@ def get_sqlalchemy_type(field: FieldInfo) -> Any:
     metadata = _get_field_metadata(field)
     if type_ is None:
         raise ValueError("Missing field type")
-    if issubclass(type_, str):
+    if issubclass(type_, str) or type_ in (EmailStr, NameEmail, ImportString):
         max_length = getattr(metadata, "max_length", None)
         if max_length:
             return AutoString(length=max_length)
@@ -692,5 +693,7 @@ def _is_field_noneable(field: FieldInfo) -> bool:
 def _get_field_metadata(field: FieldInfo) -> object:
     for meta in field.metadata:
         if isinstance(meta, PydanticGeneralMetadata):
+            return meta
+        if isinstance(meta, MaxLen):
             return meta
     return object()

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -55,10 +55,7 @@ if sys.version_info >= (3, 8):
 else:
     from typing_extensions import get_args, get_origin
 
-if sys.version_info >= (3, 9):
-    from typing import Annotated, _AnnotatedAlias
-else:
-    from typing_extensions import Annotated, _AnnotatedAlias
+from typing_extensions import Annotated, _AnnotatedAlias
 
 _T = TypeVar("_T")
 NoArgAnyCallable = Callable[[], Any]

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -24,8 +24,7 @@ from typing import (
     Type,
     TypeVar,
     Union,
-    cast,
-    get_args
+    cast
 )
 import types
 
@@ -46,6 +45,8 @@ from sqlalchemy.orm.instrumentation import is_instrumented
 from sqlalchemy.orm.properties import MappedColumn
 from sqlalchemy.sql.schema import MetaData, DefaultClause
 from sqlalchemy.sql.sqltypes import LargeBinary, Time
+from sqlalchemy.sql import false, true
+
 
 from .sql.sqltypes import GUID, AutoString
 from .typing import SQLModelConfig
@@ -179,8 +180,19 @@ def Field(
         #server_default -> default
         if isinstance(sa_column_, Column) and isinstance(sa_column_.server_default, DefaultClause):
             default_value =  sa_column_.server_default.arg
-            if issubclass( type(sa_column_.type), Integer):
+            if issubclass( type(sa_column_.type), Integer) and isinstance(default_value, str):
                 default = int(default_value)
+            elif issubclass( type(sa_column_.type), Boolean):
+                if default_value is false():
+                    default = False
+                elif default_value is true():
+                    default = True
+                elif isinstance(default_value, str):
+                    if default_value == '1':
+                        default =True
+                    elif default_value == '0':
+                        default = False
+                    
 
     field_info = FieldInfo(
         default,

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -177,7 +177,7 @@ def Field(
 ) -> Any:
     current_schema_extra = schema_extra or {}
     if default is PydanticUndefined:
-        if type(sa_column) is types.FunctionType: #lambda 
+        if isinstance(sa_column, types.FunctionType): #lambda 
             sa_column_ = sa_column()
         else:
             sa_column_ = sa_column

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -10,7 +10,7 @@ from enum import Enum
 from pathlib import Path
 from typing import (
     AbstractSet,
-    Any, 
+    Any,
     Callable,
     ClassVar,
     Dict,
@@ -24,7 +24,7 @@ from typing import (
     Type,
     TypeVar,
     Union,
-    cast
+    cast,
 )
 import types
 
@@ -55,7 +55,7 @@ if sys.version_info >= (3, 8):
     from typing import get_args, get_origin
 else:
     from typing_extensions import get_args, get_origin
-    
+
 if sys.version_info >= (3, 9):
     from typing import Annotated
 else:
@@ -177,27 +177,30 @@ def Field(
 ) -> Any:
     current_schema_extra = schema_extra or {}
     if default is PydanticUndefined:
-        if isinstance(sa_column, types.FunctionType): #lambda 
+        if isinstance(sa_column, types.FunctionType):  # lambda
             sa_column_ = sa_column()
         else:
             sa_column_ = sa_column
-            
-        #server_default -> default
-        if isinstance(sa_column_, Column) and isinstance(sa_column_.server_default, DefaultClause):
-            default_value =  sa_column_.server_default.arg
-            if issubclass( type(sa_column_.type), Integer) and isinstance(default_value, str):
+
+        # server_default -> default
+        if isinstance(sa_column_, Column) and isinstance(
+            sa_column_.server_default, DefaultClause
+        ):
+            default_value = sa_column_.server_default.arg
+            if issubclass(type(sa_column_.type), Integer) and isinstance(
+                default_value, str
+            ):
                 default = int(default_value)
-            elif issubclass( type(sa_column_.type), Boolean):
+            elif issubclass(type(sa_column_.type), Boolean):
                 if default_value is false():
                     default = False
                 elif default_value is true():
                     default = True
                 elif isinstance(default_value, str):
-                    if default_value == '1':
-                        default =True
-                    elif default_value == '0':
+                    if default_value == "1":
+                        default = True
+                    elif default_value == "0":
                         default = False
-                    
 
     field_info = FieldInfo(
         default,
@@ -447,6 +450,7 @@ def get_sqlalchemy_type(field: FieldInfo) -> Any:
             return get_origin(type_) in (types.UnionType, Union)
         else:
             return get_origin(type_) is Union
+
     if type_ is not None and is_optional_or_union(type_):
         bases = get_args(type_)
         if len(bases) > 2:
@@ -455,17 +459,17 @@ def get_sqlalchemy_type(field: FieldInfo) -> Any:
             )
         type_ = bases[0]
     # Resolve Annoted fields,
-    # like typing.Annotated[pydantic_core._pydantic_core.Url, 
-    # UrlConstraints(max_length=512, 
+    # like typing.Annotated[pydantic_core._pydantic_core.Url,
+    # UrlConstraints(max_length=512,
     # allowed_schemes=['smb', 'ftp', 'file']) ]
     if type_ is pydantic.AnyUrl:
-        meta =  field.metadata[0]
+        meta = field.metadata[0]
         return AutoString(length=meta.max_length)
-    
-    if  get_origin(type_) is Annotated:
+
+    if get_origin(type_) is Annotated:
         type2 = get_args(type_)[0]
         if type2 is pydantic.AnyUrl:
-            meta =  get_args(type_)[1]
+            meta = get_args(type_)[1]
             return AutoString(length=meta.max_length)
 
     # The 3rd is PydanticGeneralMetadata

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -467,11 +467,14 @@ def get_sqlalchemy_type(field: FieldInfo) -> Any:
         meta = field.metadata[0]
         return AutoString(length=meta.max_length)
 
-    if get_origin(type_) is Annotated:
+    org_type = get_origin(type_)
+    if org_type is Annotated:
         type2 = get_args(type_)[0]
         if type2 is pydantic.AnyUrl:
             meta = get_args(type_)[1]
             return AutoString(length=meta.max_length)
+    elif org_type is pydantic.AnyUrl:
+        return AutoString(type_.__metadata__[0].max_length)
 
     # The 3rd is PydanticGeneralMetadata
     metadata = _get_field_metadata(field)

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -167,7 +167,7 @@ def Field(
     unique: bool = False,
     nullable: Union[bool, PydanticUndefinedType] = PydanticUndefined,
     index: Union[bool, PydanticUndefinedType] = PydanticUndefined,
-    sa_column: Union[Column, PydanticUndefinedType, types.FunctionType] = PydanticUndefined,  # type: ignore
+    sa_column: Union[Column, PydanticUndefinedType, Callable[[], Column]] = PydanticUndefined,  # type: ignore
     sa_column_args: Union[Sequence[Any], PydanticUndefinedType] = PydanticUndefined,
     sa_column_kwargs: Union[
         Mapping[str, Any], PydanticUndefinedType
@@ -525,7 +525,9 @@ def get_column_from_field(field: FieldInfo) -> Column:  # type: ignore
     if isinstance(sa_column, MappedColumn):
         return sa_column.column
     if isinstance(sa_column, types.FunctionType):
-        return sa_column()
+        col = sa_column()
+        assert isinstance(col, Column)
+        return col
     sa_type = get_sqlalchemy_type(field)
     primary_key = getattr(field, "primary_key", False)
     index = getattr(field, "index", PydanticUndefined)

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -525,23 +525,14 @@ def get_column_from_field(field: FieldInfo) -> Column:  # type: ignore
     sa_column > field attributes > annotation info
     """
     sa_column = getattr(field, "sa_column", PydanticUndefined)
-    col: Column | None = None
     if isinstance(sa_column, Column):
-        col = sa_column
-    elif isinstance(sa_column, MappedColumn):
-        col = sa_column.column
-    elif isinstance(sa_column, types.FunctionType):
+        return sa_column
+    if isinstance(sa_column, MappedColumn):
+        return sa_column.column
+    if isinstance(sa_column, types.FunctionType):
         col = sa_column()
-    if isinstance(col, Column):
-        # field attribute or field annotation -> Column.nullable
-        if col.nullable is PydanticUndefined:
-            col.nullable = _is_field_noneable(field)
-        # field.primary_key -> Column.primary_key
-        if col.primary_key is PydanticUndefined:
-            primary_key = getattr(field, "primary_key", False)
-            col.primary_key = primary_key
+        assert isinstance(col, Column)
         return col
-
     sa_type = get_sqlalchemy_type(field)
     primary_key = getattr(field, "primary_key", False)
     index = getattr(field, "index", PydanticUndefined)

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -56,7 +56,7 @@ else:
     from typing_extensions import get_args, get_origin
 
 if sys.version_info >= (3, 9):
-    from typing import Annotated
+    from typing import Annotated, _AnnotatedAlias
 else:
     from typing_extensions import Annotated, _AnnotatedAlias
 

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -649,7 +649,10 @@ class SQLModel(BaseModel, metaclass=SQLModelMetaclass, registry=default_registry
         # remove defaults so they don't get validated
         data = {}
         for key, value in validated:
-            field = cls.model_fields[key]
+            field = cls.model_fields.get(key)
+
+            if field is None:
+                continue
 
             if (
                 hasattr(field, "default")

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -666,15 +666,14 @@ def _is_field_noneable(field: FieldInfo) -> bool:
         return field.nullable
     if not field.is_required():
         default = getattr(field, "original_default", field.default)
-        if default is PydanticUndefined:
-            return False
         if field.annotation is None or field.annotation is NoneType:
             return True
         if _is_optional_or_union(field.annotation):
             for base in get_args(field.annotation):
                 if base is NoneType:
                     return True
-
+        if default is PydanticUndefined:
+            return False
         return False
     return False
 

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -442,7 +442,7 @@ def get_sqlalchemy_type(field: FieldInfo) -> Any:
     type_: Optional[type] = field.annotation
 
     # Resolve Optional/Union fields
-    def is_optional_or_union(type_):
+    def is_optional_or_union(type_: Optional[type]) -> bool:
         if sys.version_info >= (3, 10):
             return get_origin(type_) in (types.UnionType, Union)
         else:

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -58,7 +58,7 @@ else:
 if sys.version_info >= (3, 9):
     from typing import Annotated
 else:
-    from typing_extensions import Annotated
+    from typing_extensions import Annotated, _AnnotatedAlias
 
 _T = TypeVar("_T")
 NoArgAnyCallable = Callable[[], Any]

--- a/sqlmodel/orm/session.py
+++ b/sqlmodel/orm/session.py
@@ -12,9 +12,7 @@ from typing import (
 
 from sqlalchemy import util
 from sqlalchemy.orm import Mapper as _Mapper
-from sqlalchemy.orm import Query as _Query
 from sqlalchemy.orm import Session as _Session
-from sqlalchemy.sql.base import Executable as _Executable
 from sqlalchemy.sql.selectable import ForUpdateArg as _ForUpdateArg
 from sqlmodel.sql.expression import Select, SelectOfScalar
 
@@ -81,56 +79,6 @@ class Session(_Session):
             return results.scalars()  # type: ignore
         return results  # type: ignore
 
-    def execute(
-        self,
-        statement: _Executable,
-        params: Optional[Union[Mapping[str, Any], Sequence[Mapping[str, Any]]]] = None,
-        execution_options: Mapping[str, Any] = util.EMPTY_DICT,
-        bind_arguments: Optional[Dict[str, Any]] = None,
-        _parent_execute_state: Optional[Any] = None,
-        _add_event: Optional[Any] = None,
-        **kw: Any,
-    ) -> Result[Any]:
-        """
-        🚨 You probably want to use `session.exec()` instead of `session.execute()`.
-
-        This is the original SQLAlchemy `session.execute()` method that returns objects
-        of type `Row`, and that you have to call `scalars()` to get the model objects.
-
-        For example:
-
-        ```Python
-        heroes = session.execute(select(Hero)).scalars().all()
-        ```
-
-        instead you could use `exec()`:
-
-        ```Python
-        heroes = session.exec(select(Hero)).all()
-        ```
-        """
-        return super().execute(  # type: ignore
-            statement,
-            params=params,
-            execution_options=execution_options,
-            bind_arguments=bind_arguments,
-            _parent_execute_state=_parent_execute_state,
-            _add_event=_add_event,
-            **kw,
-        )
-
-    def query(self, *entities: Any, **kwargs: Any) -> "_Query[Any]":
-        """
-        🚨 You probably want to use `session.exec()` instead of `session.query()`.
-
-        `session.exec()` is SQLModel's own short version with increased type
-        annotations.
-
-        Or otherwise you might want to use `session.execute()` instead of
-        `session.query()`.
-        """
-        return super().query(*entities, **kwargs)  # type: ignore
-
     def get(
         self,
         entity: Union[Type[_TSelectParam], "_Mapper[_TSelectParam]"],
@@ -152,3 +100,34 @@ class Session(_Session):
             execution_options=execution_options,
             bind_arguments=bind_arguments,
         )
+
+
+Session.query.__doc__ = """
+🚨 You probably want to use `session.exec()` instead of `session.query()`.
+
+`session.exec()` is SQLModel's own short version with increased type
+annotations.
+
+Or otherwise you might want to use `session.execute()` instead of
+`session.query()`.
+"""
+
+
+Session.execute.__doc__ = """
+🚨 You probably want to use `session.exec()` instead of `session.execute()`.
+
+This is the original SQLAlchemy `session.execute()` method that returns objects
+of type `Row`, and that you have to call `scalars()` to get the model objects.
+
+For example:
+
+```Python
+heroes = session.execute(select(Hero)).scalars().all()
+```
+
+instead you could use `exec()`:
+
+```Python
+heroes = session.exec(select(Hero)).all()
+```
+"""

--- a/sqlmodel/sql/expression.py
+++ b/sqlmodel/sql/expression.py
@@ -35,6 +35,14 @@ class SelectOfScalar(_Select[Tuple[_TSelect]], Generic[_TSelect]):
     inherit_cache = True
 
 
+# This is not comparable to sqlalchemy.sql.selectable.ScalarSelect, that has a different
+# purpose. This is the same as a normal SQLAlchemy Select class where there's only one
+# entity, so the result will be converted to a scalar by default. This way writing
+# for loops on the results will feel natural.
+class SelectOfScalar(_Select, Generic[_TSelect]):
+    inherit_cache = True
+
+
 if TYPE_CHECKING:  # pragma: no cover
     from ..main import SQLModel
 

--- a/sqlmodel/sql/expression.py
+++ b/sqlmodel/sql/expression.py
@@ -35,14 +35,6 @@ class SelectOfScalar(_Select[Tuple[_TSelect]], Generic[_TSelect]):
     inherit_cache = True
 
 
-# This is not comparable to sqlalchemy.sql.selectable.ScalarSelect, that has a different
-# purpose. This is the same as a normal SQLAlchemy Select class where there's only one
-# entity, so the result will be converted to a scalar by default. This way writing
-# for loops on the results will feel natural.
-class SelectOfScalar(_Select, Generic[_TSelect]):
-    inherit_cache = True
-
-
 if TYPE_CHECKING:  # pragma: no cover
     from ..main import SQLModel
 

--- a/sqlmodel/sql/expression.py.jinja2
+++ b/sqlmodel/sql/expression.py.jinja2
@@ -30,12 +30,6 @@ class Select(_Select[Tuple[_TSelect]], Generic[_TSelect]):
 class SelectOfScalar(_Select[Tuple[_TSelect]], Generic[_TSelect]):
     inherit_cache = True
 
-# This is not comparable to sqlalchemy.sql.selectable.ScalarSelect, that has a different
-# purpose. This is the same as a normal SQLAlchemy Select class where there's only one
-# entity, so the result will be converted to a scalar by default. This way writing
-# for loops on the results will feel natural.
-class SelectOfScalar(_Select, Generic[_TSelect]):
-    inherit_cache = True
 
 if TYPE_CHECKING:  # pragma: no cover
     from ..main import SQLModel

--- a/sqlmodel/sql/sqltypes.py
+++ b/sqlmodel/sql/sqltypes.py
@@ -8,7 +8,6 @@ from sqlalchemy.sql.type_api import TypeEngine
 
 
 class AutoString(types.TypeDecorator):  # type: ignore
-
     impl = types.String
     cache_ok = True
     mysql_default_length = 255

--- a/tests/test_class_hierarchy.py
+++ b/tests/test_class_hierarchy.py
@@ -1,0 +1,79 @@
+import datetime
+import sys
+
+import pytest
+from pydantic import AnyUrl, UrlConstraints
+from typing_extensions import Annotated
+
+from sqlmodel import (
+    BigInteger,
+    Column,
+    DateTime,
+    Field,
+    Integer,
+    SQLModel,
+    String,
+    create_engine,
+)
+
+MoveSharedUrl = Annotated[
+    AnyUrl, UrlConstraints(max_length=512, allowed_schemes=["smb", "ftp", "file"])
+]
+
+
+@pytest.mark.skipif(sys.version_info < (3, 10))
+def test_field_resuse():
+    class BasicFileLog(SQLModel):
+        resourceID: int = Field(
+            sa_column=lambda: Column(Integer, index=True), description="""   """
+        )
+        transportID: Annotated[int | None, Field(description=" for ")] = None
+        fileName: str = Field(
+            sa_column=lambda: Column(String, index=True), description=""" """
+        )
+        fileSize: int | None = Field(
+            sa_column=lambda: Column(BigInteger), ge=0, description=""" """
+        )
+        beginTime: datetime.datetime | None = Field(
+            sa_column=lambda: Column(
+                DateTime(timezone=True),
+                index=True,
+            ),
+            description="",
+        )
+
+    class SendFileLog(BasicFileLog, table=True):
+        id: int | None = Field(
+            sa_column=Column(Integer, primary_key=True, autoincrement=True),
+            description="""   """,
+        )
+        sendUser: str
+        dstUrl: MoveSharedUrl | None
+
+    class RecvFileLog(BasicFileLog, table=True):
+        id: int | None = Field(
+            sa_column=Column(Integer, primary_key=True, autoincrement=True),
+            description="""   """,
+        )
+        recvUser: str
+
+    sqlite_file_name = "database.db"
+    sqlite_url = f"sqlite:///{sqlite_file_name}"
+
+    engine = create_engine(sqlite_url, echo=True)
+    SQLModel.metadata.drop_all(engine)
+    SQLModel.metadata.create_all(engine)
+    SendFileLog(
+        sendUser="j",
+        resourceID=1,
+        fileName="a.txt",
+        fileSize=3234,
+        beginTime=datetime.datetime.now(),
+    )
+    RecvFileLog(
+        sendUser="j",
+        resourceID=1,
+        fileName="a.txt",
+        fileSize=3234,
+        beginTime=datetime.datetime.now(),
+    )

--- a/tests/test_class_hierarchy.py
+++ b/tests/test_class_hierarchy.py
@@ -3,8 +3,6 @@ import sys
 
 import pytest
 from pydantic import AnyUrl, UrlConstraints
-from typing_extensions import Annotated
-
 from sqlmodel import (
     BigInteger,
     Column,
@@ -15,6 +13,7 @@ from sqlmodel import (
     String,
     create_engine,
 )
+from typing_extensions import Annotated
 
 MoveSharedUrl = Annotated[
     AnyUrl, UrlConstraints(max_length=512, allowed_schemes=["smb", "ftp", "file"])

--- a/tests/test_class_hierarchy.py
+++ b/tests/test_class_hierarchy.py
@@ -20,7 +20,7 @@ MoveSharedUrl = Annotated[
 ]
 
 
-@pytest.mark.skipif(sys.version_info < (3, 10))
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="requires python3.10 or higher")
 def test_field_resuse():
     class BasicFileLog(SQLModel):
         resourceID: int = Field(

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from sqlmodel.default import Default
 
 
@@ -9,7 +11,7 @@ def test_default_bool() -> None:
     df1 = Default(False)
     df2 = Default(0)
     df3 = Default("")
-    df4: list = Default([])
+    df4: list[Any] = Default([])
     df5 = Default(None)
 
     assert not not dt1

--- a/tests/test_model_copy.py
+++ b/tests/test_model_copy.py
@@ -1,0 +1,49 @@
+from typing import Optional
+
+import pytest
+from pydantic import field_validator
+from pydantic.error_wrappers import ValidationError
+from sqlmodel import SQLModel, create_engine, Session, Field
+
+
+def test_model_copy(clear_sqlmodel):
+    """Test validation of implicit and explict None values.
+
+    # For consistency with pydantic, validators are not to be called on
+    # arguments that are not explicitly provided.
+
+    https://github.com/tiangolo/sqlmodel/issues/230
+    https://github.com/samuelcolvin/pydantic/issues/1223
+
+    """
+
+    class Hero(SQLModel, table=True):
+        id: Optional[int] = Field(default=None, primary_key=True)
+        name: str
+        secret_name: str
+        age: Optional[int] = None
+
+    hero = Hero(name="Deadpond", secret_name="Dive Wilson", age=25)
+
+    engine = create_engine("sqlite://")
+
+    SQLModel.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        session.add(hero)
+        session.commit()
+        session.refresh(hero)
+
+    model_copy = hero.model_copy(update={"name": "Deadpond Copy"})
+
+    assert model_copy.name == "Deadpond Copy" and \
+           model_copy.secret_name == "Dive Wilson" and \
+           model_copy.age == 25
+
+    db_hero = session.get(Hero, hero.id)
+
+    db_copy = db_hero.model_copy(update={"name": "Deadpond Copy"})
+
+    assert db_copy.name == "Deadpond Copy" and \
+           db_copy.secret_name == "Dive Wilson" and \
+           db_copy.age == 25

--- a/tests/test_model_copy.py
+++ b/tests/test_model_copy.py
@@ -1,8 +1,5 @@
 from typing import Optional
 
-import pytest
-from pydantic import field_validator
-from pydantic.error_wrappers import ValidationError
 from sqlmodel import Field, Session, SQLModel, create_engine
 
 

--- a/tests/test_model_copy.py
+++ b/tests/test_model_copy.py
@@ -3,7 +3,7 @@ from typing import Optional
 import pytest
 from pydantic import field_validator
 from pydantic.error_wrappers import ValidationError
-from sqlmodel import SQLModel, create_engine, Session, Field
+from sqlmodel import Field, Session, SQLModel, create_engine
 
 
 def test_model_copy(clear_sqlmodel):
@@ -36,14 +36,18 @@ def test_model_copy(clear_sqlmodel):
 
     model_copy = hero.model_copy(update={"name": "Deadpond Copy"})
 
-    assert model_copy.name == "Deadpond Copy" and \
-           model_copy.secret_name == "Dive Wilson" and \
-           model_copy.age == 25
+    assert (
+        model_copy.name == "Deadpond Copy"
+        and model_copy.secret_name == "Dive Wilson"
+        and model_copy.age == 25
+    )
 
     db_hero = session.get(Hero, hero.id)
 
     db_copy = db_hero.model_copy(update={"name": "Deadpond Copy"})
 
-    assert db_copy.name == "Deadpond Copy" and \
-           db_copy.secret_name == "Dive Wilson" and \
-           db_copy.age == 25
+    assert (
+        db_copy.name == "Deadpond Copy"
+        and db_copy.secret_name == "Dive Wilson"
+        and db_copy.age == 25
+    )

--- a/tests/test_nullable.py
+++ b/tests/test_nullable.py
@@ -3,6 +3,9 @@ from typing import Optional
 import pytest
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import Field, Session, SQLModel, create_engine
+from typing_extensions import Annotated
+from pydantic import AnyUrl, UrlConstraints
+MoveSharedUrl =  Annotated[AnyUrl, UrlConstraints(max_length=512, allowed_schemes=['smb', 'ftp','file'])]
 
 
 def test_nullable_fields(clear_sqlmodel, caplog):
@@ -49,6 +52,7 @@ def test_nullable_fields(clear_sqlmodel, caplog):
         str_default_str_nullable: str = Field(default="default", nullable=True)
         str_default_ellipsis_non_nullable: str = Field(default=..., nullable=False)
         str_default_ellipsis_nullable: str = Field(default=..., nullable=True)
+        annotated_any_url: MoveSharedUrl | None = Field(description="")
 
     engine = create_engine("sqlite://", echo=True)
     SQLModel.metadata.create_all(engine)
@@ -77,6 +81,7 @@ def test_nullable_fields(clear_sqlmodel, caplog):
     assert "str_default_str_nullable VARCHAR," in create_table_log
     assert "str_default_ellipsis_non_nullable VARCHAR NOT NULL," in create_table_log
     assert "str_default_ellipsis_nullable VARCHAR," in create_table_log
+    assert "annotated_any_url  VARCHAR(512)," in create_table_log
 
 
 # Test for regression in https://github.com/tiangolo/sqlmodel/issues/420

--- a/tests/test_nullable.py
+++ b/tests/test_nullable.py
@@ -1,11 +1,14 @@
 from typing import Optional
 
 import pytest
+from pydantic import AnyUrl, UrlConstraints
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import Field, Session, SQLModel, create_engine
 from typing_extensions import Annotated
-from pydantic import AnyUrl, UrlConstraints
-MoveSharedUrl =  Annotated[AnyUrl, UrlConstraints(max_length=512, allowed_schemes=['smb', 'ftp','file'])]
+
+MoveSharedUrl = Annotated[
+    AnyUrl, UrlConstraints(max_length=512, allowed_schemes=["smb", "ftp", "file"])
+]
 
 
 def test_nullable_fields(clear_sqlmodel, caplog):

--- a/tests/test_nullable.py
+++ b/tests/test_nullable.py
@@ -57,7 +57,7 @@ def test_nullable_fields(clear_sqlmodel, caplog):
         str_default_str_nullable: str = Field(default="default", nullable=True)
         str_default_ellipsis_non_nullable: str = Field(default=..., nullable=False)
         str_default_ellipsis_nullable: str = Field(default=..., nullable=True)
-        base_url : AnyUrl
+        base_url: AnyUrl
         optional_url: Optional[MoveSharedUrl] = Field(default=None, description="")
         url: MoveSharedUrl
         annotated_url: Annotated[MoveSharedUrl, Field(description="")]

--- a/tests/test_nullable.py
+++ b/tests/test_nullable.py
@@ -19,6 +19,8 @@ def test_nullable_fields(clear_sqlmodel, caplog):
         )
         required_value: str
         optional_default_ellipsis: Optional[str] = Field(default=...)
+        optional_no_field: Optional[str]
+        optional_no_field_default: Optional[str] = Field(description="no default")
         optional_default_none: Optional[str] = Field(default=None)
         optional_non_nullable: Optional[str] = Field(
             nullable=False,
@@ -55,7 +57,7 @@ def test_nullable_fields(clear_sqlmodel, caplog):
         str_default_str_nullable: str = Field(default="default", nullable=True)
         str_default_ellipsis_non_nullable: str = Field(default=..., nullable=False)
         str_default_ellipsis_nullable: str = Field(default=..., nullable=True)
-        annotated_any_url: MoveSharedUrl | None = Field(description="")
+        annotated_any_url: Optional[MoveSharedUrl] = Field(description="")
 
     engine = create_engine("sqlite://", echo=True)
     SQLModel.metadata.create_all(engine)
@@ -66,6 +68,8 @@ def test_nullable_fields(clear_sqlmodel, caplog):
     assert "primary_key INTEGER NOT NULL," in create_table_log
     assert "required_value VARCHAR NOT NULL," in create_table_log
     assert "optional_default_ellipsis VARCHAR NOT NULL," in create_table_log
+    assert "optional_no_field VARCHAR," in create_table_log
+    assert "optional_no_field_default VARCHAR NOT NULL," in create_table_log
     assert "optional_default_none VARCHAR," in create_table_log
     assert "optional_non_nullable VARCHAR NOT NULL," in create_table_log
     assert "optional_nullable VARCHAR," in create_table_log

--- a/tests/test_nullable.py
+++ b/tests/test_nullable.py
@@ -57,7 +57,12 @@ def test_nullable_fields(clear_sqlmodel, caplog):
         str_default_str_nullable: str = Field(default="default", nullable=True)
         str_default_ellipsis_non_nullable: str = Field(default=..., nullable=False)
         str_default_ellipsis_nullable: str = Field(default=..., nullable=True)
-        annotated_any_url: Optional[MoveSharedUrl] = Field(description="")
+        optional_url: Optional[MoveSharedUrl] = Field(default=None, description="")
+        url: MoveSharedUrl
+        annotated_url: Annotated[MoveSharedUrl, Field(description="")]
+        annotated_optional_url: Annotated[
+            Optional[MoveSharedUrl], Field(description="")
+        ] = None
 
     engine = create_engine("sqlite://", echo=True)
     SQLModel.metadata.create_all(engine)
@@ -88,7 +93,10 @@ def test_nullable_fields(clear_sqlmodel, caplog):
     assert "str_default_str_nullable VARCHAR," in create_table_log
     assert "str_default_ellipsis_non_nullable VARCHAR NOT NULL," in create_table_log
     assert "str_default_ellipsis_nullable VARCHAR," in create_table_log
-    assert "annotated_any_url VARCHAR(512) NOT NULL" in create_table_log
+    assert "optional_url VARCHAR(512), " in create_table_log
+    assert "url VARCHAR(512) NOT NULL," in create_table_log
+    assert "annotated_url VARCHAR(512) NOT NULL," in create_table_log
+    assert "annotated_optional_url VARCHAR(512)," in create_table_log
 
 
 # Test for regression in https://github.com/tiangolo/sqlmodel/issues/420

--- a/tests/test_nullable.py
+++ b/tests/test_nullable.py
@@ -57,6 +57,7 @@ def test_nullable_fields(clear_sqlmodel, caplog):
         str_default_str_nullable: str = Field(default="default", nullable=True)
         str_default_ellipsis_non_nullable: str = Field(default=..., nullable=False)
         str_default_ellipsis_nullable: str = Field(default=..., nullable=True)
+        base_url : AnyUrl
         optional_url: Optional[MoveSharedUrl] = Field(default=None, description="")
         url: MoveSharedUrl
         annotated_url: Annotated[MoveSharedUrl, Field(description="")]
@@ -93,6 +94,7 @@ def test_nullable_fields(clear_sqlmodel, caplog):
     assert "str_default_str_nullable VARCHAR," in create_table_log
     assert "str_default_ellipsis_non_nullable VARCHAR NOT NULL," in create_table_log
     assert "str_default_ellipsis_nullable VARCHAR," in create_table_log
+    assert "base_url VARCHAR NOT NULL," in create_table_log
     assert "optional_url VARCHAR(512), " in create_table_log
     assert "url VARCHAR(512) NOT NULL," in create_table_log
     assert "annotated_url VARCHAR(512) NOT NULL," in create_table_log

--- a/tests/test_nullable.py
+++ b/tests/test_nullable.py
@@ -88,7 +88,7 @@ def test_nullable_fields(clear_sqlmodel, caplog):
     assert "str_default_str_nullable VARCHAR," in create_table_log
     assert "str_default_ellipsis_non_nullable VARCHAR NOT NULL," in create_table_log
     assert "str_default_ellipsis_nullable VARCHAR," in create_table_log
-    assert "annotated_any_url  VARCHAR(512)," in create_table_log
+    assert "annotated_any_url VARCHAR(512) NOT NULL" in create_table_log
 
 
 # Test for regression in https://github.com/tiangolo/sqlmodel/issues/420

--- a/tests/test_pydantic_types.py
+++ b/tests/test_pydantic_types.py
@@ -1,0 +1,24 @@
+from pydantic import EmailStr, HttpUrl, ImportString, NameEmail
+from sqlmodel import Field, SQLModel, create_engine
+
+
+def test_pydantic_types(clear_sqlmodel, caplog):
+    class Hero(SQLModel, table=True):
+        integer_primary_key: int = Field(
+            primary_key=True,
+        )
+        http: HttpUrl = Field(max_length=250)
+        email: EmailStr
+        name_email: NameEmail = Field(max_length=50)
+        import_string: ImportString = Field(max_length=200, min_length=100)
+
+    engine = create_engine("sqlite://", echo=True)
+    SQLModel.metadata.create_all(engine)
+
+    create_table_log = [
+        message for message in caplog.messages if "CREATE TABLE hero" in message
+    ][0]
+    assert "http VARCHAR(250) NOT NULL," in create_table_log
+    assert "email VARCHAR NOT NULL," in create_table_log
+    assert "name_email VARCHAR(50) NOT NULL," in create_table_log
+    assert "import_string VARCHAR(200) NOT NULL," in create_table_log

--- a/tests/test_tutorial/test_fastapi/test_delete/test_tutorial001.py
+++ b/tests/test_tutorial/test_fastapi/test_delete/test_tutorial001.py
@@ -3,7 +3,7 @@ from sqlmodel import create_engine
 from sqlmodel.pool import StaticPool
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/heroes/": {
@@ -210,7 +210,10 @@ openapi_schema = {
                 "properties": {
                     "name": {"title": "Name", "type": "string"},
                     "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                 },
             },
             "HeroRead": {
@@ -220,7 +223,10 @@ openapi_schema = {
                 "properties": {
                     "name": {"title": "Name", "type": "string"},
                     "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                     "id": {"title": "Id", "type": "integer"},
                 },
             },
@@ -228,9 +234,18 @@ openapi_schema = {
                 "title": "HeroUpdate",
                 "type": "object",
                 "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
+                    "name": {
+                        "title": "Name",
+                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                    },
+                    "secret_name": {
+                        "title": "Secret Name",
+                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                    },
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                 },
             },
             "ValidationError": {
@@ -241,7 +256,7 @@ openapi_schema = {
                     "loc": {
                         "title": "Location",
                         "type": "array",
-                        "items": {"type": "string"},
+                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
                     },
                     "msg": {"title": "Message", "type": "string"},
                     "type": {"title": "Error Type", "type": "string"},
@@ -261,7 +276,6 @@ def test_tutorial(clear_sqlmodel):
     )
 
     with TestClient(mod.app) as client:
-
         hero1_data = {"name": "Deadpond", "secret_name": "Dive Wilson"}
         hero2_data = {
             "name": "Spider-Boy",

--- a/tests/test_tutorial/test_fastapi/test_limit_and_offset/test_tutorial001.py
+++ b/tests/test_tutorial/test_fastapi/test_limit_and_offset/test_tutorial001.py
@@ -3,7 +3,7 @@ from sqlmodel import create_engine
 from sqlmodel.pool import StaticPool
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/heroes/": {
@@ -142,7 +142,10 @@ openapi_schema = {
                 "properties": {
                     "name": {"title": "Name", "type": "string"},
                     "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                 },
             },
             "HeroRead": {
@@ -152,7 +155,10 @@ openapi_schema = {
                 "properties": {
                     "name": {"title": "Name", "type": "string"},
                     "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                     "id": {"title": "Id", "type": "integer"},
                 },
             },
@@ -164,7 +170,7 @@ openapi_schema = {
                     "loc": {
                         "title": "Location",
                         "type": "array",
-                        "items": {"type": "string"},
+                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
                     },
                     "msg": {"title": "Message", "type": "string"},
                     "type": {"title": "Error Type", "type": "string"},
@@ -184,7 +190,6 @@ def test_tutorial(clear_sqlmodel):
     )
 
     with TestClient(mod.app) as client:
-
         hero1_data = {"name": "Deadpond", "secret_name": "Dive Wilson"}
         hero2_data = {
             "name": "Spider-Boy",

--- a/tests/test_tutorial/test_fastapi/test_multiple_models/test_tutorial001.py
+++ b/tests/test_tutorial/test_fastapi/test_multiple_models/test_tutorial001.py
@@ -5,7 +5,7 @@ from sqlmodel import create_engine
 from sqlmodel.pool import StaticPool
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/heroes/": {
@@ -81,7 +81,10 @@ openapi_schema = {
                 "properties": {
                     "name": {"title": "Name", "type": "string"},
                     "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                 },
             },
             "HeroRead": {
@@ -92,7 +95,10 @@ openapi_schema = {
                     "id": {"title": "Id", "type": "integer"},
                     "name": {"title": "Name", "type": "string"},
                     "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                 },
             },
             "ValidationError": {
@@ -103,7 +109,7 @@ openapi_schema = {
                     "loc": {
                         "title": "Location",
                         "type": "array",
-                        "items": {"type": "string"},
+                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
                     },
                     "msg": {"title": "Message", "type": "string"},
                     "type": {"title": "Error Type", "type": "string"},
@@ -123,7 +129,6 @@ def test_tutorial(clear_sqlmodel):
     )
 
     with TestClient(mod.app) as client:
-
         hero1_data = {"name": "Deadpond", "secret_name": "Dive Wilson"}
         hero2_data = {
             "name": "Spider-Boy",

--- a/tests/test_tutorial/test_fastapi/test_multiple_models/test_tutorial002.py
+++ b/tests/test_tutorial/test_fastapi/test_multiple_models/test_tutorial002.py
@@ -5,7 +5,7 @@ from sqlmodel import create_engine
 from sqlmodel.pool import StaticPool
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/heroes/": {
@@ -81,7 +81,10 @@ openapi_schema = {
                 "properties": {
                     "name": {"title": "Name", "type": "string"},
                     "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                 },
             },
             "HeroRead": {
@@ -91,7 +94,10 @@ openapi_schema = {
                 "properties": {
                     "name": {"title": "Name", "type": "string"},
                     "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                     "id": {"title": "Id", "type": "integer"},
                 },
             },
@@ -103,7 +109,7 @@ openapi_schema = {
                     "loc": {
                         "title": "Location",
                         "type": "array",
-                        "items": {"type": "string"},
+                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
                     },
                     "msg": {"title": "Message", "type": "string"},
                     "type": {"title": "Error Type", "type": "string"},
@@ -123,7 +129,6 @@ def test_tutorial(clear_sqlmodel):
     )
 
     with TestClient(mod.app) as client:
-
         hero1_data = {"name": "Deadpond", "secret_name": "Dive Wilson"}
         hero2_data = {
             "name": "Spider-Boy",

--- a/tests/test_tutorial/test_fastapi/test_read_one/test_tutorial001.py
+++ b/tests/test_tutorial/test_fastapi/test_read_one/test_tutorial001.py
@@ -3,7 +3,7 @@ from sqlmodel import create_engine
 from sqlmodel.pool import StaticPool
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/heroes/": {
@@ -113,7 +113,10 @@ openapi_schema = {
                 "properties": {
                     "name": {"title": "Name", "type": "string"},
                     "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                 },
             },
             "HeroRead": {
@@ -123,7 +126,10 @@ openapi_schema = {
                 "properties": {
                     "name": {"title": "Name", "type": "string"},
                     "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                     "id": {"title": "Id", "type": "integer"},
                 },
             },
@@ -135,7 +141,7 @@ openapi_schema = {
                     "loc": {
                         "title": "Location",
                         "type": "array",
-                        "items": {"type": "string"},
+                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
                     },
                     "msg": {"title": "Message", "type": "string"},
                     "type": {"title": "Error Type", "type": "string"},
@@ -155,7 +161,6 @@ def test_tutorial(clear_sqlmodel):
     )
 
     with TestClient(mod.app) as client:
-
         hero1_data = {"name": "Deadpond", "secret_name": "Dive Wilson"}
         hero2_data = {
             "name": "Spider-Boy",

--- a/tests/test_tutorial/test_fastapi/test_relationships/test_tutorial001.py
+++ b/tests/test_tutorial/test_fastapi/test_relationships/test_tutorial001.py
@@ -3,7 +3,7 @@ from sqlmodel import create_engine
 from sqlmodel.pool import StaticPool
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/heroes/": {
@@ -397,8 +397,14 @@ openapi_schema = {
                 "properties": {
                     "name": {"title": "Name", "type": "string"},
                     "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
-                    "team_id": {"title": "Team Id", "type": "integer"},
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
+                    "team_id": {
+                        "title": "Team Id",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                 },
             },
             "HeroRead": {
@@ -408,8 +414,14 @@ openapi_schema = {
                 "properties": {
                     "name": {"title": "Name", "type": "string"},
                     "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
-                    "team_id": {"title": "Team Id", "type": "integer"},
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
+                    "team_id": {
+                        "title": "Team Id",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                     "id": {"title": "Id", "type": "integer"},
                 },
             },
@@ -420,20 +432,43 @@ openapi_schema = {
                 "properties": {
                     "name": {"title": "Name", "type": "string"},
                     "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
-                    "team_id": {"title": "Team Id", "type": "integer"},
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
+                    "team_id": {
+                        "title": "Team Id",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                     "id": {"title": "Id", "type": "integer"},
-                    "team": {"$ref": "#/components/schemas/TeamRead"},
+                    "team": {
+                        "anyOf": [
+                            {"$ref": "#/components/schemas/TeamRead"},
+                            {"type": "null"},
+                        ]
+                    },
                 },
             },
             "HeroUpdate": {
                 "title": "HeroUpdate",
                 "type": "object",
                 "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
-                    "team_id": {"title": "Team Id", "type": "integer"},
+                    "name": {
+                        "title": "Name",
+                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                    },
+                    "secret_name": {
+                        "title": "Secret Name",
+                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                    },
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
+                    "team_id": {
+                        "title": "Team Id",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                 },
             },
             "TeamCreate": {
@@ -475,9 +510,18 @@ openapi_schema = {
                 "title": "TeamUpdate",
                 "type": "object",
                 "properties": {
-                    "id": {"title": "Id", "type": "integer"},
-                    "name": {"title": "Name", "type": "string"},
-                    "headquarters": {"title": "Headquarters", "type": "string"},
+                    "id": {
+                        "title": "Id",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
+                    "name": {
+                        "title": "Name",
+                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                    },
+                    "headquarters": {
+                        "title": "Headquarters",
+                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                    },
                 },
             },
             "ValidationError": {
@@ -488,7 +532,7 @@ openapi_schema = {
                     "loc": {
                         "title": "Location",
                         "type": "array",
-                        "items": {"type": "string"},
+                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
                     },
                     "msg": {"title": "Message", "type": "string"},
                     "type": {"title": "Error Type", "type": "string"},

--- a/tests/test_tutorial/test_fastapi/test_response_model/test_tutorial001.py
+++ b/tests/test_tutorial/test_fastapi/test_response_model/test_tutorial001.py
@@ -3,7 +3,7 @@ from sqlmodel import create_engine
 from sqlmodel.pool import StaticPool
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/heroes/": {
@@ -74,13 +74,18 @@ openapi_schema = {
             },
             "Hero": {
                 "title": "Hero",
-                "required": ["name", "secret_name"],
                 "type": "object",
                 "properties": {
-                    "id": {"title": "Id", "type": "integer"},
+                    "id": {
+                        "title": "Id",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                     "name": {"title": "Name", "type": "string"},
                     "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                 },
             },
             "ValidationError": {
@@ -91,7 +96,9 @@ openapi_schema = {
                     "loc": {
                         "title": "Location",
                         "type": "array",
-                        "items": {"type": "string"},
+                        "items": {
+                            "anyOf": [{"type": "string"}, {"type": "integer"}],
+                        },
                     },
                     "msg": {"title": "Message", "type": "string"},
                     "type": {"title": "Error Type", "type": "string"},
@@ -111,7 +118,6 @@ def test_tutorial(clear_sqlmodel):
     )
 
     with TestClient(mod.app) as client:
-
         hero_data = {"name": "Deadpond", "secret_name": "Dive Wilson"}
         response = client.post("/heroes/", json=hero_data)
         data = response.json()

--- a/tests/test_tutorial/test_fastapi/test_session_with_dependency/test_tutorial001.py
+++ b/tests/test_tutorial/test_fastapi/test_session_with_dependency/test_tutorial001.py
@@ -3,7 +3,7 @@ from sqlmodel import create_engine
 from sqlmodel.pool import StaticPool
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/heroes/": {
@@ -210,7 +210,10 @@ openapi_schema = {
                 "properties": {
                     "name": {"title": "Name", "type": "string"},
                     "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                 },
             },
             "HeroRead": {
@@ -220,7 +223,10 @@ openapi_schema = {
                 "properties": {
                     "name": {"title": "Name", "type": "string"},
                     "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                     "id": {"title": "Id", "type": "integer"},
                 },
             },
@@ -228,9 +234,18 @@ openapi_schema = {
                 "title": "HeroUpdate",
                 "type": "object",
                 "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
+                    "name": {
+                        "title": "Name",
+                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                    },
+                    "secret_name": {
+                        "title": "Secret Name",
+                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                    },
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                 },
             },
             "ValidationError": {
@@ -241,7 +256,9 @@ openapi_schema = {
                     "loc": {
                         "title": "Location",
                         "type": "array",
-                        "items": {"type": "string"},
+                        "items": {
+                            "anyOf": [{"type": "string"}, {"type": "integer"}],
+                        },
                     },
                     "msg": {"title": "Message", "type": "string"},
                     "type": {"title": "Error Type", "type": "string"},
@@ -261,7 +278,6 @@ def test_tutorial(clear_sqlmodel):
     )
 
     with TestClient(mod.app) as client:
-
         hero1_data = {"name": "Deadpond", "secret_name": "Dive Wilson"}
         hero2_data = {
             "name": "Spider-Boy",

--- a/tests/test_tutorial/test_fastapi/test_simple_hero_api/test_tutorial001.py
+++ b/tests/test_tutorial/test_fastapi/test_simple_hero_api/test_tutorial001.py
@@ -3,7 +3,7 @@ from sqlmodel import create_engine
 from sqlmodel.pool import StaticPool
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/heroes/": {
@@ -62,13 +62,18 @@ openapi_schema = {
             },
             "Hero": {
                 "title": "Hero",
-                "required": ["name", "secret_name"],
                 "type": "object",
                 "properties": {
-                    "id": {"title": "Id", "type": "integer"},
+                    "id": {
+                        "title": "Id",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                     "name": {"title": "Name", "type": "string"},
                     "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                 },
             },
             "ValidationError": {
@@ -79,7 +84,9 @@ openapi_schema = {
                     "loc": {
                         "title": "Location",
                         "type": "array",
-                        "items": {"type": "string"},
+                        "items": {
+                            "anyOf": [{"type": "string"}, {"type": "integer"}],
+                        },
                     },
                     "msg": {"title": "Message", "type": "string"},
                     "type": {"title": "Error Type", "type": "string"},
@@ -99,7 +106,6 @@ def test_tutorial(clear_sqlmodel):
     )
 
     with TestClient(mod.app) as client:
-
         hero1_data = {"name": "Deadpond", "secret_name": "Dive Wilson"}
         hero2_data = {
             "name": "Spider-Boy",

--- a/tests/test_tutorial/test_fastapi/test_teams/test_tutorial001.py
+++ b/tests/test_tutorial/test_fastapi/test_teams/test_tutorial001.py
@@ -3,7 +3,7 @@ from sqlmodel import create_engine
 from sqlmodel.pool import StaticPool
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/heroes/": {
@@ -393,8 +393,14 @@ openapi_schema = {
                 "properties": {
                     "name": {"title": "Name", "type": "string"},
                     "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
-                    "team_id": {"title": "Team Id", "type": "integer"},
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
+                    "team_id": {
+                        "title": "Team Id",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                 },
             },
             "HeroRead": {
@@ -404,8 +410,14 @@ openapi_schema = {
                 "properties": {
                     "name": {"title": "Name", "type": "string"},
                     "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
-                    "team_id": {"title": "Team Id", "type": "integer"},
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
+                    "team_id": {
+                        "title": "Team Id",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                     "id": {"title": "Id", "type": "integer"},
                 },
             },
@@ -413,10 +425,22 @@ openapi_schema = {
                 "title": "HeroUpdate",
                 "type": "object",
                 "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
-                    "team_id": {"title": "Team Id", "type": "integer"},
+                    "name": {
+                        "title": "Name",
+                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                    },
+                    "secret_name": {
+                        "title": "Secret Name",
+                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                    },
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
+                    "team_id": {
+                        "title": "Team Id",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                 },
             },
             "TeamCreate": {
@@ -442,8 +466,14 @@ openapi_schema = {
                 "title": "TeamUpdate",
                 "type": "object",
                 "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "headquarters": {"title": "Headquarters", "type": "string"},
+                    "name": {
+                        "title": "Name",
+                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                    },
+                    "headquarters": {
+                        "title": "Headquarters",
+                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                    },
                 },
             },
             "ValidationError": {
@@ -454,7 +484,9 @@ openapi_schema = {
                     "loc": {
                         "title": "Location",
                         "type": "array",
-                        "items": {"type": "string"},
+                        "items": {
+                            "anyOf": [{"type": "string"}, {"type": "integer"}],
+                        },
                     },
                     "msg": {"title": "Message", "type": "string"},
                     "type": {"title": "Error Type", "type": "string"},
@@ -474,7 +506,6 @@ def test_tutorial(clear_sqlmodel):
     )
 
     with TestClient(mod.app) as client:
-
         hero1_data = {"name": "Deadpond", "secret_name": "Dive Wilson"}
         hero2_data = {
             "name": "Spider-Boy",

--- a/tests/test_tutorial/test_fastapi/test_update/test_tutorial001.py
+++ b/tests/test_tutorial/test_fastapi/test_update/test_tutorial001.py
@@ -3,7 +3,7 @@ from sqlmodel import create_engine
 from sqlmodel.pool import StaticPool
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/heroes/": {
@@ -182,7 +182,10 @@ openapi_schema = {
                 "properties": {
                     "name": {"title": "Name", "type": "string"},
                     "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                 },
             },
             "HeroRead": {
@@ -192,7 +195,10 @@ openapi_schema = {
                 "properties": {
                     "name": {"title": "Name", "type": "string"},
                     "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                     "id": {"title": "Id", "type": "integer"},
                 },
             },
@@ -200,9 +206,18 @@ openapi_schema = {
                 "title": "HeroUpdate",
                 "type": "object",
                 "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
+                    "name": {
+                        "title": "Name",
+                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                    },
+                    "secret_name": {
+                        "title": "Secret Name",
+                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                    },
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                 },
             },
             "ValidationError": {
@@ -213,7 +228,9 @@ openapi_schema = {
                     "loc": {
                         "title": "Location",
                         "type": "array",
-                        "items": {"type": "string"},
+                        "items": {
+                            "anyOf": [{"type": "string"}, {"type": "integer"}],
+                        },
                     },
                     "msg": {"title": "Message", "type": "string"},
                     "type": {"title": "Error Type", "type": "string"},
@@ -233,7 +250,6 @@ def test_tutorial(clear_sqlmodel):
     )
 
     with TestClient(mod.app) as client:
-
         hero1_data = {"name": "Deadpond", "secret_name": "Dive Wilson"}
         hero2_data = {
             "name": "Spider-Boy",


### PR DESCRIPTION
Hi @AntonDeMeester,

Thank you for your  work on updating `sqlmodels` to `pydantic2` and `sqlalchemy2`. I'm excited about the possibility of having this [pull request](https://github.com/tiangolo/sqlmodel/pull/632) merged.

I've gone ahead and forked it to make sure that all checks are passing smoothly. Here's a brief overview of the adjustments I've made:

1. **FastAPI Tutorial Tests:** I've reviewed the FastAPI tutorial tests and made sure they are now passing. It appears that they were issues due to some changes in the OpenAPI schema. Specifically, the schema version required updating, and there were adjustments required in the properties definition for nullable fields.

2. **Validation Test:** One of the tests related to validation was failing. This test was aimed at ensuring that `SQLModel` remains aligned with `Pydantic` by not executing validation on fields with default values. I've made some modifications to the `SQLModel.validate_model` method to ensure that default values are exempt from validation.

3. **Mypy Fixes:** I've addressed six `mypy` errors. These errors seem minor, but they might need review  to ensure there are no typing issues introduced. Two errors were associated with the override of the `query` and `execute` methods within the `Session` class. These overrides were primarily intended for altering docstrings, so I've updated the overrides to exclusively target the docstrings.

I've run both the `lint.sh` and `test.sh` scripts, and they are passing in my computer. Hopefully this will help to get the pull request merged.

Cheers,
Santiago