### PR TITLE
Fix TypeError for complex types

### DIFF
--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -474,6 +474,7 @@ def get_sqlalchemy_type(field: FieldInfo) -> Any:
         if type2 is pydantic.AnyUrl:
             meta = get_args(type_)[1]
             return AutoString(length=meta.max_length)
+        type_ = type2
     elif org_type is pydantic.AnyUrl and type(type_) is _AnnotatedAlias:
         return AutoString(type_.__metadata__[0].max_length)
 


### PR DESCRIPTION
I noticed a problem while trying to use optional fields with custom types. Using an optional UUID4 field (`entity_id: UUID4 | None = Field(default=None, foreign_key="entity.id")`) gives me an error:
```
...
  File "/home/user/.pyenv/versions/3.11.5/envs/env/lib/python3.11/site-packages/sqlmodel/main.py", line 358, in __new__
    col = get_column_from_field(v)
          ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/.pyenv/versions/3.11.5/envs/env/lib/python3.11/site-packages/sqlmodel/main.py", line 540, in get_column_from_field
    sa_type = get_sqlalchemy_type(field)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/.pyenv/versions/3.11.5/envs/env/lib/python3.11/site-packages/sqlmodel/main.py", line 484, in get_sqlalchemy_type
    if issubclass(type_, str) or type_ in (EmailStr, NameEmail, ImportString):
       ^^^^^^^^^^^^^^^^^^^^^^
TypeError: issubclass() arg 1 must be a class
```
This PR fixes the problem by using the original type instead of the annotation