### PR TITLE
Loosen SQLAlchemy and pydantic dependency restrictions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,8 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.7"
-SQLAlchemy = ">=2.0.0,<=2.0.21"
-pydantic = { version = ">=2.1.1,<=2.4.2", extras = ["email"] }
+SQLAlchemy = ">=2.0.0,<=2.1"
+pydantic = { version = ">=2.1.1,<=2.5", extras = ["email"] }
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.0.1"
@@ -90,16 +90,16 @@ skip_glob = [
 [tool.mypy]
 # --strict
 disallow_any_generics = true
-disallow_subclassing_any = true 
-disallow_untyped_calls = true 
+disallow_subclassing_any = true
+disallow_untyped_calls = true
 disallow_untyped_defs = true
-disallow_incomplete_defs = true 
-check_untyped_defs = true 
-disallow_untyped_decorators = true 
+disallow_incomplete_defs = true
+check_untyped_defs = true
+disallow_untyped_decorators = true
 no_implicit_optional = true
-warn_redundant_casts = true 
+warn_redundant_casts = true
 warn_unused_ignores = true
-warn_return_any = true 
+warn_return_any = true
 implicit_reexport = false
 strict_equality = true
 # --strict end


### PR DESCRIPTION
Allow to use the latest versions of `SQLAlchemy` and `pydantic`