### PR TITLE
Add Literal type handling

### DIFF
--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -52,9 +52,9 @@ from .sql.sqltypes import GUID, AutoString
 from .typing import SQLModelConfig
 
 if sys.version_info >= (3, 8):
-    from typing import get_args, get_origin
+    from typing import get_args, get_origin, Literal
 else:
-    from typing_extensions import get_args, get_origin
+    from typing_extensions import get_args, get_origin, Literal
 
 from typing_extensions import Annotated, _AnnotatedAlias
 
@@ -477,6 +477,13 @@ def get_sqlalchemy_type(field: FieldInfo) -> Any:
         type_ = type2
     elif org_type is pydantic.AnyUrl and type(type_) is _AnnotatedAlias:
         return AutoString(type_.__metadata__[0].max_length)
+    elif org_type is Literal:
+        child_types = list({type(x) for x in get_args(type_)})
+        if len(child_types) != 1:
+            raise RuntimeError(
+                "Cannot have a Literal with multiple types as a SQLAlchemy field"
+            )
+        type_ = child_types[0]
 
     # The 3rd is PydanticGeneralMetadata
     metadata = _get_field_metadata(field)

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -477,7 +477,9 @@ def get_sqlalchemy_type(field: FieldInfo) -> Any:
         type_ = type2
     elif org_type is pydantic.AnyUrl and type(type_) is _AnnotatedAlias:
         return AutoString(type_.__metadata__[0].max_length)
-    elif org_type is Literal:
+
+    # Resolve Literal fields
+    if get_origin(type_) is Literal:
         child_types = list({type(x) for x in get_args(type_)})
         if len(child_types) != 1:
             raise RuntimeError(


### PR DESCRIPTION
This PR adds support to handle a column defined to be a Literal type. The idea is that if all Literal elements are of the same type, then the SQLAlchemy column type becomes that type. Otherwise a runtime error is thrown. If there can be improvements to the logic, please let me know. 

Solution based on the discussion in tiangolo/sqlmodel/issues/57