### PR TITLE
Add support for SQLAlchemy mixins

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,11 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version:
-          - "3.7"
-          - "3.8"
-          - "3.9"
-          - "3.10"
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
       fail-fast: false
 
     steps:
@@ -56,6 +52,7 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: python -m poetry install
       - name: Lint
+        if: ${{ matrix.python-version != '3.7' }}
         run: python -m poetry run bash scripts/lint.sh
       - run: mkdir coverage
       - name: Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,6 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: python -m poetry install
       - name: Lint
-        if: ${{ matrix.python-version != '3.7' }}
         run: python -m poetry run bash scripts/lint.sh
       - run: mkdir coverage
       - name: Test

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ It combines SQLAlchemy and Pydantic and tries to simplify the code you write as 
 
 ## Requirements
 
-A recent and currently supported <a href="https://www.python.org/downloads/" class="external-link" target="_blank">version of Python Python</a>.
+A recent and currently supported version of Python (right now, <a href="https://www.python.org/downloads/" class="external-link" target="_blank">Python supports versions 3.7 and above</a>).
 
 As **SQLModel** is based on **Pydantic** and **SQLAlchemy**, it requires them. They will be automatically installed when you install SQLModel.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -8,7 +8,7 @@ If you already cloned the repository and you know that you need to deep dive in 
 
 ### Python
 
-SQLModel supports Python 3.7 and above, but for development you should have at least **Python 3.7**.
+SQLModel supports Python 3.7 and above.
 
 ### Poetry
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -6,6 +6,10 @@ First, you might want to see the basic ways to [help SQLModel and get help](help
 
 If you already cloned the repository and you know that you need to deep dive in the code, here are some guidelines to set up your environment.
 
+### Python
+
+SQLModel supports Python 3.7 and above, but for development you should have at least **Python 3.7**.
+
 ### Poetry
 
 **SQLModel** uses <a href="https://python-poetry.org/" class="external-link" target="_blank">Poetry</a> to build, package, and publish the project.

--- a/docs/features.md
+++ b/docs/features.md
@@ -12,7 +12,7 @@ Nevertheless, SQLModel is completely **independent** of FastAPI and can be used 
 
 ## Just Modern Python
 
-It's all based on standard <abbr title="Currently supported versions of Python">modern **Python**</abbr> type annotations. No new syntax to learn. Just standard modern Python.
+It's all based on standard <abbr title="Python currently supported versions, 3.7 and above.">modern **Python**</abbr> type annotations. No new syntax to learn. Just standard modern Python.
 
 If you need a 2 minute refresher of how to use Python types (even if you don't use SQLModel or FastAPI), check the FastAPI tutorial section: <a href="https://fastapi.tiangolo.com/python-types/" class="external-link" target="_blank">Python types intro</a>.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,7 +50,7 @@ It combines SQLAlchemy and Pydantic and tries to simplify the code you write as 
 
 ## Requirements
 
-A recent and currently supported <a href="https://www.python.org/downloads/" class="external-link" target="_blank">version of Python Python</a>.
+A recent and currently supported version of Python (right now, <a href="https://www.python.org/downloads/" class="external-link" target="_blank">Python supports versions 3.7 and above</a>).
 
 As **SQLModel** is based on **Pydantic** and **SQLAlchemy**, it requires them. They will be automatically installed when you install SQLModel.
 

--- a/docs/tutorial/fastapi/multiple-models.md
+++ b/docs/tutorial/fastapi/multiple-models.md
@@ -174,13 +174,13 @@ Now we use the type annotation `HeroCreate` for the request JSON data in the `he
 # Code below omitted 👇
 ```
 
-Then we create a new `Hero` (this is the actual **table** model that saves things to the database) using `Hero.from_orm()`.
+Then we create a new `Hero` (this is the actual **table** model that saves things to the database) using `Hero.model_validate()`.
 
-The method `.from_orm()` reads data from another object with attributes and creates a new instance of this class, in this case `Hero`.
+The method `.model_validate()` reads data from another object with attributes and creates a new instance of this class, in this case `Hero`.
 
 The alternative is `Hero.parse_obj()` that reads data from a dictionary.
 
-But as in this case, we have a `HeroCreate` instance in the `hero` variable. This is an object with attributes, so we use `.from_orm()` to read those attributes.
+But as in this case, we have a `HeroCreate` instance in the `hero` variable. This is an object with attributes, so we use `.model_validate()` to read those attributes.
 
 With this, we create a new `Hero` instance (the one for the database) and put it in the variable `db_hero` from the data in the `hero` variable that is the `HeroCreate` instance we received from the request.
 

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -64,6 +64,8 @@ $ cd sqlmodel-tutorial
 
 Make sure you have an officially supported version of Python.
 
+Currently it is **Python 3.7** and above (Python 3.6 was already deprecated).
+
 You can check which version you have with:
 
 <div class="termy">
@@ -82,6 +84,7 @@ You might want to try with the specific versions, for example with:
 * `python3.10`
 * `python3.9`
 * `python3.8`
+* `python3.7`
 
 The code would look like this:
 

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -81,6 +81,7 @@ There's a chance that you have multiple Python versions installed.
 
 You might want to try with the specific versions, for example with:
 
+* `python3.11`
 * `python3.10`
 * `python3.9`
 * `python3.8`

--- a/docs_src/tutorial/fastapi/app_testing/tutorial001/main.py
+++ b/docs_src/tutorial/fastapi/app_testing/tutorial001/main.py
@@ -54,7 +54,7 @@ def on_startup():
 
 @app.post("/heroes/", response_model=HeroRead)
 def create_hero(*, session: Session = Depends(get_session), hero: HeroCreate):
-    db_hero = Hero.from_orm(hero)
+    db_hero = Hero.model_validate(hero)
     session.add(db_hero)
     session.commit()
     session.refresh(db_hero)

--- a/docs_src/tutorial/fastapi/delete/tutorial001.py
+++ b/docs_src/tutorial/fastapi/delete/tutorial001.py
@@ -50,7 +50,7 @@ def on_startup():
 @app.post("/heroes/", response_model=HeroRead)
 def create_hero(hero: HeroCreate):
     with Session(engine) as session:
-        db_hero = Hero.from_orm(hero)
+        db_hero = Hero.model_validate(hero)
         session.add(db_hero)
         session.commit()
         session.refresh(db_hero)

--- a/docs_src/tutorial/fastapi/delete/tutorial001.py
+++ b/docs_src/tutorial/fastapi/delete/tutorial001.py
@@ -79,7 +79,7 @@ def update_hero(hero_id: int, hero: HeroUpdate):
         db_hero = session.get(Hero, hero_id)
         if not db_hero:
             raise HTTPException(status_code=404, detail="Hero not found")
-        hero_data = hero.dict(exclude_unset=True)
+        hero_data = hero.model_dump(exclude_unset=True)
         for key, value in hero_data.items():
             setattr(db_hero, key, value)
         session.add(db_hero)

--- a/docs_src/tutorial/fastapi/limit_and_offset/tutorial001.py
+++ b/docs_src/tutorial/fastapi/limit_and_offset/tutorial001.py
@@ -44,7 +44,7 @@ def on_startup():
 @app.post("/heroes/", response_model=HeroRead)
 def create_hero(hero: HeroCreate):
     with Session(engine) as session:
-        db_hero = Hero.from_orm(hero)
+        db_hero = Hero.model_validate(hero)
         session.add(db_hero)
         session.commit()
         session.refresh(db_hero)

--- a/docs_src/tutorial/fastapi/multiple_models/tutorial001.py
+++ b/docs_src/tutorial/fastapi/multiple_models/tutorial001.py
@@ -46,7 +46,7 @@ def on_startup():
 @app.post("/heroes/", response_model=HeroRead)
 def create_hero(hero: HeroCreate):
     with Session(engine) as session:
-        db_hero = Hero.from_orm(hero)
+        db_hero = Hero.model_validate(hero)
         session.add(db_hero)
         session.commit()
         session.refresh(db_hero)

--- a/docs_src/tutorial/fastapi/multiple_models/tutorial002.py
+++ b/docs_src/tutorial/fastapi/multiple_models/tutorial002.py
@@ -44,7 +44,7 @@ def on_startup():
 @app.post("/heroes/", response_model=HeroRead)
 def create_hero(hero: HeroCreate):
     with Session(engine) as session:
-        db_hero = Hero.from_orm(hero)
+        db_hero = Hero.model_validate(hero)
         session.add(db_hero)
         session.commit()
         session.refresh(db_hero)

--- a/docs_src/tutorial/fastapi/read_one/tutorial001.py
+++ b/docs_src/tutorial/fastapi/read_one/tutorial001.py
@@ -44,7 +44,7 @@ def on_startup():
 @app.post("/heroes/", response_model=HeroRead)
 def create_hero(hero: HeroCreate):
     with Session(engine) as session:
-        db_hero = Hero.from_orm(hero)
+        db_hero = Hero.model_validate(hero)
         session.add(db_hero)
         session.commit()
         session.refresh(db_hero)

--- a/docs_src/tutorial/fastapi/relationships/tutorial001.py
+++ b/docs_src/tutorial/fastapi/relationships/tutorial001.py
@@ -92,7 +92,7 @@ def on_startup():
 
 @app.post("/heroes/", response_model=HeroRead)
 def create_hero(*, session: Session = Depends(get_session), hero: HeroCreate):
-    db_hero = Hero.from_orm(hero)
+    db_hero = Hero.model_validate(hero)
     session.add(db_hero)
     session.commit()
     session.refresh(db_hero)
@@ -147,7 +147,7 @@ def delete_hero(*, session: Session = Depends(get_session), hero_id: int):
 
 @app.post("/teams/", response_model=TeamRead)
 def create_team(*, session: Session = Depends(get_session), team: TeamCreate):
-    db_team = Team.from_orm(team)
+    db_team = Team.model_validate(team)
     session.add(db_team)
     session.commit()
     session.refresh(db_team)

--- a/docs_src/tutorial/fastapi/session_with_dependency/tutorial001.py
+++ b/docs_src/tutorial/fastapi/session_with_dependency/tutorial001.py
@@ -54,7 +54,7 @@ def on_startup():
 
 @app.post("/heroes/", response_model=HeroRead)
 def create_hero(*, session: Session = Depends(get_session), hero: HeroCreate):
-    db_hero = Hero.from_orm(hero)
+    db_hero = Hero.model_validate(hero)
     session.add(db_hero)
     session.commit()
     session.refresh(db_hero)

--- a/docs_src/tutorial/fastapi/teams/tutorial001.py
+++ b/docs_src/tutorial/fastapi/teams/tutorial001.py
@@ -83,7 +83,7 @@ def on_startup():
 
 @app.post("/heroes/", response_model=HeroRead)
 def create_hero(*, session: Session = Depends(get_session), hero: HeroCreate):
-    db_hero = Hero.from_orm(hero)
+    db_hero = Hero.model_validate(hero)
     session.add(db_hero)
     session.commit()
     session.refresh(db_hero)
@@ -138,7 +138,7 @@ def delete_hero(*, session: Session = Depends(get_session), hero_id: int):
 
 @app.post("/teams/", response_model=TeamRead)
 def create_team(*, session: Session = Depends(get_session), team: TeamCreate):
-    db_team = Team.from_orm(team)
+    db_team = Team.model_validate(team)
     session.add(db_team)
     session.commit()
     session.refresh(db_team)

--- a/docs_src/tutorial/fastapi/update/tutorial001.py
+++ b/docs_src/tutorial/fastapi/update/tutorial001.py
@@ -50,7 +50,7 @@ def on_startup():
 @app.post("/heroes/", response_model=HeroRead)
 def create_hero(hero: HeroCreate):
     with Session(engine) as session:
-        db_hero = Hero.from_orm(hero)
+        db_hero = Hero.model_validate(hero)
         session.add(db_hero)
         session.commit()
         session.refresh(db_hero)

--- a/docs_src/tutorial/many_to_many/tutorial003.py
+++ b/docs_src/tutorial/many_to_many/tutorial003.py
@@ -3,6 +3,23 @@ from typing import List, Optional
 from sqlmodel import Field, Relationship, Session, SQLModel, create_engine, select
 
 
+class Team(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str = Field(index=True)
+    headquarters: str
+
+    hero_links: List["HeroTeamLink"] = Relationship(back_populates="team")
+
+
+class Hero(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str = Field(index=True)
+    secret_name: str
+    age: Optional[int] = Field(default=None, index=True)
+
+    team_links: List["HeroTeamLink"] = Relationship(back_populates="hero")
+
+
 class HeroTeamLink(SQLModel, table=True):
     team_id: Optional[int] = Field(
         default=None, foreign_key="team.id", primary_key=True
@@ -14,23 +31,6 @@ class HeroTeamLink(SQLModel, table=True):
 
     team: "Team" = Relationship(back_populates="hero_links")
     hero: "Hero" = Relationship(back_populates="team_links")
-
-
-class Team(SQLModel, table=True):
-    id: Optional[int] = Field(default=None, primary_key=True)
-    name: str = Field(index=True)
-    headquarters: str
-
-    hero_links: List[HeroTeamLink] = Relationship(back_populates="team")
-
-
-class Hero(SQLModel, table=True):
-    id: Optional[int] = Field(default=None, primary_key=True)
-    name: str = Field(index=True)
-    secret_name: str
-    age: Optional[int] = Field(default=None, index=True)
-
-    team_links: List[HeroTeamLink] = Relationship(back_populates="hero")
 
 
 sqlite_file_name = "database.db"

--- a/docs_src/tutorial/relationship_attributes/back_populates/tutorial003.py
+++ b/docs_src/tutorial/relationship_attributes/back_populates/tutorial003.py
@@ -3,6 +3,21 @@ from typing import List, Optional
 from sqlmodel import Field, Relationship, SQLModel, create_engine
 
 
+class Hero(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str = Field(index=True)
+    secret_name: str
+    age: Optional[int] = Field(default=None, index=True)
+
+    team_id: Optional[int] = Field(default=None, foreign_key="team.id")
+    team: Optional["Team"] = Relationship(back_populates="heroes")
+
+    weapon_id: Optional[int] = Field(default=None, foreign_key="weapon.id")
+    weapon: Optional["Weapon"] = Relationship(back_populates="hero")
+
+    powers: List["Power"] = Relationship(back_populates="hero")
+
+
 class Weapon(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     name: str = Field(index=True)
@@ -24,21 +39,6 @@ class Team(SQLModel, table=True):
     headquarters: str
 
     heroes: List["Hero"] = Relationship(back_populates="team")
-
-
-class Hero(SQLModel, table=True):
-    id: Optional[int] = Field(default=None, primary_key=True)
-    name: str = Field(index=True)
-    secret_name: str
-    age: Optional[int] = Field(default=None, index=True)
-
-    team_id: Optional[int] = Field(default=None, foreign_key="team.id")
-    team: Optional[Team] = Relationship(back_populates="heroes")
-
-    weapon_id: Optional[int] = Field(default=None, foreign_key="weapon.id")
-    weapon: Optional[Weapon] = Relationship(back_populates="hero")
-
-    powers: List[Power] = Relationship(back_populates="hero")
 
 
 sqlite_file_name = "database.db"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,8 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.7"
-SQLAlchemy = ">=2.0.0,<=2.0.21"
-pydantic = { version = ">=2.1.1,<=2.4.2", extras = ["email"] }
+SQLAlchemy = "^2.0.22"
+pydantic = { version = "^2.4.2", extras = ["email"] }
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.0.1"
@@ -90,16 +90,16 @@ skip_glob = [
 [tool.mypy]
 # --strict
 disallow_any_generics = true
-disallow_subclassing_any = true 
-disallow_untyped_calls = true 
+disallow_subclassing_any = true
+disallow_untyped_calls = true
 disallow_untyped_defs = true
-disallow_incomplete_defs = true 
-check_untyped_defs = true 
-disallow_untyped_decorators = true 
+disallow_incomplete_defs = true
+check_untyped_defs = true
+disallow_untyped_decorators = true
 no_implicit_optional = true
-warn_redundant_casts = true 
+warn_redundant_casts = true
 warn_unused_ignores = true
-warn_return_any = true 
+warn_return_any = true
 implicit_reexport = false
 strict_equality = true
 # --strict end

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Topic :: Database",
     "Topic :: Database :: Database Engines/Servers",
     "Topic :: Internet",
@@ -49,6 +50,8 @@ fastapi = "^0.68.1"
 requests = "^2.26.0"
 autoflake = "^1.4"
 isort = "^5.9.3"
+async_generator = {version = "*", python = "~3.7"}
+async-exit-stack = {version = "*", python = "~3.7"}
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,9 +31,8 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.7"
-SQLAlchemy = ">=1.4.17,<=1.4.41"
+SQLAlchemy = ">=2.0.0,<=2.0.5.post1"
 pydantic = "^1.8.2"
-sqlalchemy2-stubs = {version = "*", allow-prereleases = true}
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.0.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.7"
 SQLAlchemy = ">=2.0.0,<=2.0.11"
-pydantic = "^2.1.1"
+pydantic = { version = ">=2.1.1,<=2.4", extras = ["email"] }
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.0.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ autoflake = "^1.4"
 isort = "^5.9.3"
 async_generator = {version = "*", python = "~3.7"}
 async-exit-stack = {version = "*", python = "~3.7"}
+importlib-metadata = { version = "*", python = ">3.7" }
 httpx = "^0.24.1"
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.7"
 SQLAlchemy = ">=2.0.0,<=2.0.11"
-pydantic = "^1.8.2"
+pydantic = "^2.1.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.0.1"
@@ -46,12 +46,13 @@ pillow = "^9.3.0"
 cairosvg = "^2.5.2"
 mdx-include = "^1.4.1"
 coverage = {extras = ["toml"], version = "^6.2"}
-fastapi = "^0.68.1"
+fastapi = "^0.100.0"
 requests = "^2.26.0"
 autoflake = "^1.4"
 isort = "^5.9.3"
 async_generator = {version = "*", python = "~3.7"}
 async-exit-stack = {version = "*", python = "~3.7"}
+httpx = "^0.24.1"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.7"
-SQLAlchemy = ">=2.0.0,<=2.0.5.post1"
+SQLAlchemy = ">=2.0.0,<=2.0.11"
 pydantic = "^1.8.2"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,21 +32,21 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.7"
-SQLAlchemy = ">=2.0.0,<=2.0.11"
-pydantic = { version = ">=2.1.1,<=2.4", extras = ["email"] }
+SQLAlchemy = ">=2.0.0,<=2.0.21"
+pydantic = { version = ">=2.1.1,<=2.4.2", extras = ["email"] }
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.0.1"
 mypy = "0.971"
-flake8 = "^5.0.4"
+flake8 = [{ version = ">=5.0.4, <6.0.0", python = "<3.8.1" }, { version = ">=6.1.0", python = ">=3.8.1"}]
 black = "^22.10.0"
-mkdocs = "^1.2.1"
-mkdocs-material = "^8.1.4"
+mkdocs = [{ version = "<=1.2.4", python = "<3.8.1" }, { version = ">=1.5.3", python = ">=3.8.1"} ]
+mkdocs-material = [{ version = "<=8.2.7", python = "<3.8.1" }, { version = ">=9.4.5", python = ">=3.8.1"}]
 pillow = "^9.3.0"
 cairosvg = "^2.5.2"
 mdx-include = "^1.4.1"
 coverage = {extras = ["toml"], version = "^6.2"}
-fastapi = "^0.100.0"
+fastapi = "^0.103.2"
 requests = "^2.26.0"
 autoflake = "^1.4"
 isort = "^5.9.3"

--- a/sqlmodel/__init__.py
+++ b/sqlmodel/__init__.py
@@ -70,6 +70,7 @@ from sqlalchemy.sql import or_ as or_
 from sqlalchemy.sql import outerjoin as outerjoin
 from sqlalchemy.sql import outparam as outparam
 from sqlalchemy.sql import over as over
+from sqlalchemy.sql import Subquery as Subquery
 from sqlalchemy.sql import table as table
 from sqlalchemy.sql import tablesample as tablesample
 from sqlalchemy.sql import text as text

--- a/sqlmodel/__init__.py
+++ b/sqlmodel/__init__.py
@@ -21,7 +21,6 @@ from sqlalchemy.schema import MetaData as MetaData
 from sqlalchemy.schema import PrimaryKeyConstraint as PrimaryKeyConstraint
 from sqlalchemy.schema import Sequence as Sequence
 from sqlalchemy.schema import Table as Table
-from sqlalchemy.schema import ThreadLocalMetaData as ThreadLocalMetaData
 from sqlalchemy.schema import UniqueConstraint as UniqueConstraint
 from sqlalchemy.sql import alias as alias
 from sqlalchemy.sql import all_ as all_
@@ -71,7 +70,6 @@ from sqlalchemy.sql import or_ as or_
 from sqlalchemy.sql import outerjoin as outerjoin
 from sqlalchemy.sql import outparam as outparam
 from sqlalchemy.sql import over as over
-from sqlalchemy.sql import subquery as subquery
 from sqlalchemy.sql import table as table
 from sqlalchemy.sql import tablesample as tablesample
 from sqlalchemy.sql import text as text

--- a/sqlmodel/engine/create.py
+++ b/sqlmodel/engine/create.py
@@ -136,4 +136,4 @@ def create_engine(
     if not isinstance(query_cache_size, _DefaultPlaceholder):
         current_kwargs["query_cache_size"] = query_cache_size
     current_kwargs.update(kwargs)
-    return _create_engine(url, **current_kwargs)  # type: ignore
+    return _create_engine(url, **current_kwargs)

--- a/sqlmodel/engine/result.py
+++ b/sqlmodel/engine/result.py
@@ -1,4 +1,4 @@
-from typing import Generic, Iterator, List, Optional, TypeVar
+from typing import Generic, Iterator, List, Optional, Sequence, TypeVar
 
 from sqlalchemy.engine.result import Result as _Result
 from sqlalchemy.engine.result import ScalarResult as _ScalarResult
@@ -6,24 +6,24 @@ from sqlalchemy.engine.result import ScalarResult as _ScalarResult
 _T = TypeVar("_T")
 
 
-class ScalarResult(_ScalarResult, Generic[_T]):
-    def all(self) -> List[_T]:
+class ScalarResult(_ScalarResult[_T], Generic[_T]):
+    def all(self) -> Sequence[_T]:
         return super().all()
 
-    def partitions(self, size: Optional[int] = None) -> Iterator[List[_T]]:
+    def partitions(self, size: Optional[int] = None) -> Iterator[Sequence[_T]]:
         return super().partitions(size)
 
-    def fetchall(self) -> List[_T]:
+    def fetchall(self) -> Sequence[_T]:
         return super().fetchall()
 
-    def fetchmany(self, size: Optional[int] = None) -> List[_T]:
+    def fetchmany(self, size: Optional[int] = None) -> Sequence[_T]:
         return super().fetchmany(size)
 
     def __iter__(self) -> Iterator[_T]:
         return super().__iter__()
 
     def __next__(self) -> _T:
-        return super().__next__()  # type: ignore
+        return super().__next__()
 
     def first(self) -> Optional[_T]:
         return super().first()
@@ -32,10 +32,10 @@ class ScalarResult(_ScalarResult, Generic[_T]):
         return super().one_or_none()
 
     def one(self) -> _T:
-        return super().one()  # type: ignore
+        return super().one()
 
 
-class Result(_Result, Generic[_T]):
+class Result(_Result[_T], Generic[_T]):
     def scalars(self, index: int = 0) -> ScalarResult[_T]:
         return super().scalars(index)  # type: ignore
 
@@ -76,4 +76,4 @@ class Result(_Result, Generic[_T]):
         return super().one()  # type: ignore
 
     def scalar(self) -> Optional[_T]:
-        return super().scalar()
+        return super().scalar()  # type: ignore

--- a/sqlmodel/engine/result.py
+++ b/sqlmodel/engine/result.py
@@ -1,4 +1,4 @@
-from typing import Generic, Iterator, List, Optional, Sequence, TypeVar
+from typing import Generic, Iterator, List, Optional, Sequence, Tuple, TypeVar
 
 from sqlalchemy.engine.result import Result as _Result
 from sqlalchemy.engine.result import ScalarResult as _ScalarResult
@@ -35,7 +35,7 @@ class ScalarResult(_ScalarResult[_T], Generic[_T]):
         return super().one()
 
 
-class Result(_Result[_T], Generic[_T]):
+class Result(_Result[Tuple[_T]], Generic[_T]):
     def scalars(self, index: int = 0) -> ScalarResult[_T]:
         return super().scalars(index)  # type: ignore
 

--- a/sqlmodel/engine/result.py
+++ b/sqlmodel/engine/result.py
@@ -67,7 +67,7 @@ class Result(_Result[Tuple[_T]], Generic[_T]):
         return super().one_or_none()  # type: ignore
 
     def scalar_one(self) -> _T:
-        return super().scalar_one()  # type: ignore
+        return super().scalar_one()
 
     def scalar_one_or_none(self) -> Optional[_T]:
         return super().scalar_one_or_none()
@@ -76,4 +76,4 @@ class Result(_Result[Tuple[_T]], Generic[_T]):
         return super().one()  # type: ignore
 
     def scalar(self) -> Optional[_T]:
-        return super().scalar()  # type: ignore
+        return super().scalar()

--- a/sqlmodel/engine/result.py
+++ b/sqlmodel/engine/result.py
@@ -1,4 +1,4 @@
-from typing import Generic, Iterator, List, Optional, Sequence, Tuple, TypeVar
+from typing import Generic, Iterator, Optional, Sequence, Tuple, TypeVar
 
 from sqlalchemy.engine.result import Result as _Result
 from sqlalchemy.engine.result import ScalarResult as _ScalarResult
@@ -36,44 +36,4 @@ class ScalarResult(_ScalarResult[_T], Generic[_T]):
 
 
 class Result(_Result[Tuple[_T]], Generic[_T]):
-    def scalars(self, index: int = 0) -> ScalarResult[_T]:
-        return super().scalars(index)  # type: ignore
-
-    def __iter__(self) -> Iterator[_T]:  # type: ignore
-        return super().__iter__()  # type: ignore
-
-    def __next__(self) -> _T:  # type: ignore
-        return super().__next__()  # type: ignore
-
-    def partitions(self, size: Optional[int] = None) -> Iterator[List[_T]]:  # type: ignore
-        return super().partitions(size)  # type: ignore
-
-    def fetchall(self) -> List[_T]:  # type: ignore
-        return super().fetchall()  # type: ignore
-
-    def fetchone(self) -> Optional[_T]:  # type: ignore
-        return super().fetchone()  # type: ignore
-
-    def fetchmany(self, size: Optional[int] = None) -> List[_T]:  # type: ignore
-        return super().fetchmany()  # type: ignore
-
-    def all(self) -> List[_T]:  # type: ignore
-        return super().all()  # type: ignore
-
-    def first(self) -> Optional[_T]:  # type: ignore
-        return super().first()  # type: ignore
-
-    def one_or_none(self) -> Optional[_T]:  # type: ignore
-        return super().one_or_none()  # type: ignore
-
-    def scalar_one(self) -> _T:
-        return super().scalar_one()
-
-    def scalar_one_or_none(self) -> Optional[_T]:
-        return super().scalar_one_or_none()
-
-    def one(self) -> _T:  # type: ignore
-        return super().one()  # type: ignore
-
-    def scalar(self) -> Optional[_T]:
-        return super().scalar()
+    ...

--- a/sqlmodel/ext/asyncio/session.py
+++ b/sqlmodel/ext/asyncio/session.py
@@ -1,9 +1,11 @@
-from typing import Any, Mapping, Optional, Sequence, TypeVar, Union
+from typing import Any, Dict, Mapping, Optional, Sequence, Type, TypeVar, Union
 
 from sqlalchemy import util
 from sqlalchemy.ext.asyncio import AsyncSession as _AsyncSession
 from sqlalchemy.ext.asyncio import engine
 from sqlalchemy.ext.asyncio.engine import AsyncConnection, AsyncEngine
+from sqlalchemy.orm import Mapper
+from sqlalchemy.sql.expression import TableClause
 from sqlalchemy.util.concurrency import greenlet_spawn
 from sqlmodel.sql.base import Executable
 
@@ -14,13 +16,18 @@ from ...sql.expression import Select
 _T = TypeVar("_T")
 
 
+BindsType = Dict[
+    Union[Type[Any], Mapper[Any], TableClause, str], Union[AsyncEngine, AsyncConnection]
+]
+
+
 class AsyncSession(_AsyncSession):
     sync_session: Session
 
     def __init__(
         self,
         bind: Optional[Union[AsyncConnection, AsyncEngine]] = None,
-        binds: Optional[Mapping[object, Union[AsyncConnection, AsyncEngine]]] = None,
+        binds: Optional[BindsType] = None,
         **kw: Any,
     ):
         # All the same code of the original AsyncSession

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -19,19 +19,17 @@ from typing import (
     Set,
     Tuple,
     Type,
-    TypeVar,
+    TypeVar,ForwardRef,
     Union,
-    cast,
+    cast,get_origin,get_args
 )
 
-from pydantic import BaseConfig, BaseModel
-from pydantic.errors import ConfigError, DictError
-from pydantic.fields import SHAPE_SINGLETON
+from pydantic import BaseModel, ValidationError
+from pydantic_core import PydanticUndefined, PydanticUndefinedType
 from pydantic.fields import FieldInfo as PydanticFieldInfo
-from pydantic.fields import ModelField, Undefined, UndefinedType
-from pydantic.main import ModelMetaclass, validate_model
-from pydantic.typing import NoArgAnyCallable, resolve_annotations
-from pydantic.utils import ROOT_KEY, Representation
+from pydantic._internal._model_construction import ModelMetaclass
+from pydantic._internal._repr import Representation
+from pydantic._internal._fields import PydanticGeneralMetadata
 from sqlalchemy import Boolean, Column, Date, DateTime
 from sqlalchemy import Enum as sa_Enum
 from sqlalchemy import Float, ForeignKey, Integer, Interval, Numeric, inspect
@@ -43,8 +41,10 @@ from sqlalchemy.sql.schema import MetaData
 from sqlalchemy.sql.sqltypes import LargeBinary, Time
 
 from .sql.sqltypes import GUID, AutoString
+from .typing import SQLModelConfig
 
 _T = TypeVar("_T")
+NoArgAnyCallable = Callable[[], Any]
 
 
 def __dataclass_transform__(
@@ -58,22 +58,22 @@ def __dataclass_transform__(
 
 
 class FieldInfo(PydanticFieldInfo):
-    def __init__(self, default: Any = Undefined, **kwargs: Any) -> None:
+    def __init__(self, default: Any = PydanticUndefined, **kwargs: Any) -> None:
         primary_key = kwargs.pop("primary_key", False)
-        nullable = kwargs.pop("nullable", Undefined)
-        foreign_key = kwargs.pop("foreign_key", Undefined)
+        nullable = kwargs.pop("nullable", PydanticUndefined)
+        foreign_key = kwargs.pop("foreign_key", PydanticUndefined)
         unique = kwargs.pop("unique", False)
-        index = kwargs.pop("index", Undefined)
-        sa_column = kwargs.pop("sa_column", Undefined)
-        sa_column_args = kwargs.pop("sa_column_args", Undefined)
-        sa_column_kwargs = kwargs.pop("sa_column_kwargs", Undefined)
-        if sa_column is not Undefined:
-            if sa_column_args is not Undefined:
+        index = kwargs.pop("index", PydanticUndefined)
+        sa_column = kwargs.pop("sa_column", PydanticUndefined)
+        sa_column_args = kwargs.pop("sa_column_args", PydanticUndefined)
+        sa_column_kwargs = kwargs.pop("sa_column_kwargs", PydanticUndefined)
+        if sa_column is not PydanticUndefined:
+            if sa_column_args is not PydanticUndefined:
                 raise RuntimeError(
                     "Passing sa_column_args is not supported when "
                     "also passing a sa_column"
                 )
-            if sa_column_kwargs is not Undefined:
+            if sa_column_kwargs is not PydanticUndefined:
                 raise RuntimeError(
                     "Passing sa_column_kwargs is not supported when "
                     "also passing a sa_column"
@@ -118,7 +118,7 @@ class RelationshipInfo(Representation):
 
 
 def Field(
-    default: Any = Undefined,
+    default: Any = PydanticUndefined,
     *,
     default_factory: Optional[NoArgAnyCallable] = None,
     alias: Optional[str] = None,
@@ -145,11 +145,11 @@ def Field(
     primary_key: bool = False,
     foreign_key: Optional[Any] = None,
     unique: bool = False,
-    nullable: Union[bool, UndefinedType] = Undefined,
-    index: Union[bool, UndefinedType] = Undefined,
-    sa_column: Union[Column, UndefinedType] = Undefined,  # type: ignore
-    sa_column_args: Union[Sequence[Any], UndefinedType] = Undefined,
-    sa_column_kwargs: Union[Mapping[str, Any], UndefinedType] = Undefined,
+    nullable: Union[bool, PydanticUndefinedType] = PydanticUndefined,
+    index: Union[bool, PydanticUndefinedType] = PydanticUndefined,
+    sa_column: Union[Column, PydanticUndefinedType] = PydanticUndefined,  # type: ignore
+    sa_column_args: Union[Sequence[Any], PydanticUndefinedType] = PydanticUndefined,
+    sa_column_kwargs: Union[Mapping[str, Any], PydanticUndefinedType] = PydanticUndefined,
     schema_extra: Optional[Dict[str, Any]] = None,
 ) -> Any:
     current_schema_extra = schema_extra or {}
@@ -183,7 +183,6 @@ def Field(
         sa_column_kwargs=sa_column_kwargs,
         **current_schema_extra,
     )
-    field_info._validate()
     return field_info
 
 
@@ -191,7 +190,7 @@ def Relationship(
     *,
     back_populates: Optional[str] = None,
     link_model: Optional[Any] = None,
-    sa_relationship: Optional[RelationshipProperty] = None,  # type: ignore
+    sa_relationship: Optional[RelationshipProperty] = None,
     sa_relationship_args: Optional[Sequence[Any]] = None,
     sa_relationship_kwargs: Optional[Mapping[str, Any]] = None,
 ) -> Any:
@@ -208,18 +207,18 @@ def Relationship(
 @__dataclass_transform__(kw_only_default=True, field_descriptors=(Field, FieldInfo))
 class SQLModelMetaclass(ModelMetaclass, DeclarativeMeta):
     __sqlmodel_relationships__: Dict[str, RelationshipInfo]
-    __config__: Type[BaseConfig]
-    __fields__: Dict[str, ModelField]
+    model_config: Type[SQLModelConfig]
+    model_fields: Dict[str, FieldInfo]
 
     # Replicate SQLAlchemy
     def __setattr__(cls, name: str, value: Any) -> None:
-        if getattr(cls.__config__, "table", False):
+        if cls.model_config.get("table", False):
             DeclarativeMeta.__setattr__(cls, name, value)
         else:
             super().__setattr__(name, value)
 
     def __delattr__(cls, name: str) -> None:
-        if getattr(cls.__config__, "table", False):
+        if cls.model_config.get("table", False):
             DeclarativeMeta.__delattr__(cls, name)
         else:
             super().__delattr__(name)
@@ -232,11 +231,10 @@ class SQLModelMetaclass(ModelMetaclass, DeclarativeMeta):
         class_dict: Dict[str, Any],
         **kwargs: Any,
     ) -> Any:
+        
         relationships: Dict[str, RelationshipInfo] = {}
         dict_for_pydantic = {}
-        original_annotations = resolve_annotations(
-            class_dict.get("__annotations__", {}), class_dict.get("__module__", None)
-        )
+        original_annotations = class_dict.get("__annotations__", {})
         pydantic_annotations = {}
         relationship_annotations = {}
         for k, v in class_dict.items():
@@ -260,7 +258,7 @@ class SQLModelMetaclass(ModelMetaclass, DeclarativeMeta):
         # superclass causing an error
         allowed_config_kwargs: Set[str] = {
             key
-            for key in dir(BaseConfig)
+            for key in dir(SQLModelConfig)
             if not (
                 key.startswith("__") and key.endswith("__")
             )  # skip dunder methods and attributes
@@ -270,41 +268,49 @@ class SQLModelMetaclass(ModelMetaclass, DeclarativeMeta):
             key: pydantic_kwargs.pop(key)
             for key in pydantic_kwargs.keys() & allowed_config_kwargs
         }
+        config_table = getattr(class_dict.get('Config', object()), 'table', False)
+        # If we have a table, we need to have defaults for all fields
+        # Pydantic v2 sets a __pydantic_core_schema__ which is very hard to change. Changing the fields does not do anything
+        if config_table is True:
+            for key in original_annotations.keys():
+                if dict_used.get(key, PydanticUndefined) is PydanticUndefined:
+                    dict_used[key] = None
+        
         new_cls = super().__new__(cls, name, bases, dict_used, **config_kwargs)
         new_cls.__annotations__ = {
             **relationship_annotations,
             **pydantic_annotations,
             **new_cls.__annotations__,
         }
-
+        
         def get_config(name: str) -> Any:
-            config_class_value = getattr(new_cls.__config__, name, Undefined)
-            if config_class_value is not Undefined:
+            config_class_value = new_cls.model_config.get(name, PydanticUndefined)
+            if config_class_value is not PydanticUndefined:
                 return config_class_value
-            kwarg_value = kwargs.get(name, Undefined)
-            if kwarg_value is not Undefined:
+            kwarg_value = kwargs.get(name, PydanticUndefined)
+            if kwarg_value is not PydanticUndefined:
                 return kwarg_value
-            return Undefined
+            return PydanticUndefined
 
         config_table = get_config("table")
         if config_table is True:
             # If it was passed by kwargs, ensure it's also set in config
-            new_cls.__config__.table = config_table
-            for k, v in new_cls.__fields__.items():
+            new_cls.model_config['table'] = config_table
+            for k, v in new_cls.model_fields.items():
                 col = get_column_from_field(v)
                 setattr(new_cls, k, col)
             # Set a config flag to tell FastAPI that this should be read with a field
             # in orm_mode instead of preemptively converting it to a dict.
-            # This could be done by reading new_cls.__config__.table in FastAPI, but
+            # This could be done by reading new_cls.model_config['table'] in FastAPI, but
             # that's very specific about SQLModel, so let's have another config that
             # other future tools based on Pydantic can use.
-            new_cls.__config__.read_with_orm_mode = True
+            new_cls.model_config['read_from_attributes'] = True
 
         config_registry = get_config("registry")
-        if config_registry is not Undefined:
+        if config_registry is not PydanticUndefined:
             config_registry = cast(registry, config_registry)
             # If it was passed by kwargs, ensure it's also set in config
-            new_cls.__config__.registry = config_table
+            new_cls.model_config['registry'] = config_table
             setattr(new_cls, "_sa_registry", config_registry)
             setattr(new_cls, "metadata", config_registry.metadata)
             setattr(new_cls, "__abstract__", True)
@@ -320,13 +326,13 @@ class SQLModelMetaclass(ModelMetaclass, DeclarativeMeta):
         # triggers an error
         base_is_table = False
         for base in bases:
-            config = getattr(base, "__config__")
+            config = getattr(base, "model_config")
             if config and getattr(config, "table", False):
                 base_is_table = True
                 break
-        if getattr(cls.__config__, "table", False) and not base_is_table:
+        if cls.model_config.get("table", False) and not base_is_table:
             dict_used = dict_.copy()
-            for field_name, field_value in cls.__fields__.items():
+            for field_name, field_value in cls.model_fields.items():
                 dict_used[field_name] = get_column_from_field(field_value)
             for rel_name, rel_info in cls.__sqlmodel_relationships__.items():
                 if rel_info.sa_relationship:
@@ -335,16 +341,15 @@ class SQLModelMetaclass(ModelMetaclass, DeclarativeMeta):
                     dict_used[rel_name] = rel_info.sa_relationship
                     continue
                 ann = cls.__annotations__[rel_name]
-                temp_field = ModelField.infer(
-                    name=rel_name,
-                    value=rel_info,
-                    annotation=ann,
-                    class_validators=None,
-                    config=BaseConfig,
-                )
-                relationship_to = temp_field.type_
-                if isinstance(temp_field.type_, ForwardRef):
-                    relationship_to = temp_field.type_.__forward_arg__
+                relationship_to = get_origin(ann)
+                # If Union (Optional), get the real field
+                if relationship_to is Union:
+                    relationship_to = get_args(ann)[0]
+                # If a list, then also get the real field
+                elif relationship_to is list:
+                    relationship_to = get_args(ann)[0]
+                if isinstance(relationship_to, ForwardRef):
+                    relationship_to = relationship_to.__forward_arg__
                 rel_kwargs: Dict[str, Any] = {}
                 if rel_info.back_populates:
                     rel_kwargs["back_populates"] = rel_info.back_populates
@@ -362,7 +367,7 @@ class SQLModelMetaclass(ModelMetaclass, DeclarativeMeta):
                     rel_args.extend(rel_info.sa_relationship_args)
                 if rel_info.sa_relationship_kwargs:
                     rel_kwargs.update(rel_info.sa_relationship_kwargs)
-                rel_value: RelationshipProperty = relationship(  # type: ignore
+                rel_value: RelationshipProperty = relationship( 
                     relationship_to, *rel_args, **rel_kwargs
                 )
                 dict_used[rel_name] = rel_value
@@ -372,68 +377,78 @@ class SQLModelMetaclass(ModelMetaclass, DeclarativeMeta):
             ModelMetaclass.__init__(cls, classname, bases, dict_, **kw)
 
 
-def get_sqlalchemy_type(field: ModelField) -> Any:
-    if issubclass(field.type_, str):
-        if field.field_info.max_length:
-            return AutoString(length=field.field_info.max_length)
+def get_sqlalchemy_type(field: FieldInfo) -> Any:
+    type_ = field.annotation
+    # Resolve Optional fields
+    if type_ is not None and get_origin(type_) is Union:
+        bases = get_args(type_)
+        if len(bases) > 2:
+            raise RuntimeError("Cannot have a (non-optional) union as a SQL alchemy field")
+        type_ = bases[0]     
+
+    # The 3rd is PydanticGeneralMetadata
+    metadata = _get_field_metadata(field)
+    if issubclass(type_, str):
+        if getattr(metadata, "max_length", None):
+            return AutoString(length=metadata.max_length)
         return AutoString
-    if issubclass(field.type_, float):
+    if issubclass(type_, float):
         return Float
-    if issubclass(field.type_, bool):
+    if issubclass(type_, bool):
         return Boolean
-    if issubclass(field.type_, int):
+    if issubclass(type_, int):
         return Integer
-    if issubclass(field.type_, datetime):
+    if issubclass(type_, datetime):
         return DateTime
-    if issubclass(field.type_, date):
+    if issubclass(type_, date):
         return Date
-    if issubclass(field.type_, timedelta):
+    if issubclass(type_, timedelta):
         return Interval
-    if issubclass(field.type_, time):
+    if issubclass(type_, time):
         return Time
-    if issubclass(field.type_, Enum):
-        return sa_Enum(field.type_)
-    if issubclass(field.type_, bytes):
+    if issubclass(type_, Enum):
+        return sa_Enum(type_)
+    if issubclass(type_, bytes):
         return LargeBinary
-    if issubclass(field.type_, Decimal):
+    if issubclass(type_, Decimal):
         return Numeric(
-            precision=getattr(field.type_, "max_digits", None),
-            scale=getattr(field.type_, "decimal_places", None),
+            precision=getattr(metadata, "max_digits", None),
+            scale=getattr(metadata, "decimal_places", None),
         )
-    if issubclass(field.type_, ipaddress.IPv4Address):
+    if issubclass(type_, ipaddress.IPv4Address):
         return AutoString
-    if issubclass(field.type_, ipaddress.IPv4Network):
+    if issubclass(type_, ipaddress.IPv4Network):
         return AutoString
-    if issubclass(field.type_, ipaddress.IPv6Address):
+    if issubclass(type_, ipaddress.IPv6Address):
         return AutoString
-    if issubclass(field.type_, ipaddress.IPv6Network):
+    if issubclass(type_, ipaddress.IPv6Network):
         return AutoString
-    if issubclass(field.type_, Path):
+    if issubclass(type_, Path):
         return AutoString
-    if issubclass(field.type_, uuid.UUID):
+    if issubclass(type_, uuid.UUID):
         return GUID
-    raise ValueError(f"The field {field.name} has no matching SQLAlchemy type")
+    raise ValueError(f"The field {field.title} has no matching SQLAlchemy type")
 
 
-def get_column_from_field(field: ModelField) -> Column:  # type: ignore
-    sa_column = getattr(field.field_info, "sa_column", Undefined)
+def get_column_from_field(field: FieldInfo) -> Column:  # type: ignore
+    sa_column = getattr(field, "sa_column", PydanticUndefined)
     if isinstance(sa_column, Column):
         return sa_column
     sa_type = get_sqlalchemy_type(field)
-    primary_key = getattr(field.field_info, "primary_key", False)
-    index = getattr(field.field_info, "index", Undefined)
-    if index is Undefined:
+    primary_key = getattr(field, "primary_key", False)
+    index = getattr(field, "index", PydanticUndefined)
+    if index is PydanticUndefined:
         index = False
     nullable = not primary_key and _is_field_noneable(field)
     # Override derived nullability if the nullable property is set explicitly
     # on the field
-    if hasattr(field.field_info, "nullable"):
-        field_nullable = getattr(field.field_info, "nullable")
-        if field_nullable != Undefined:
+    if hasattr(field, "nullable"):
+        field_nullable = getattr(field, "nullable")
+        if field_nullable != PydanticUndefined:
             nullable = field_nullable
     args = []
-    foreign_key = getattr(field.field_info, "foreign_key", None)
-    unique = getattr(field.field_info, "unique", False)
+    foreign_key = getattr(field, "foreign_key", None)
+    unique = getattr(field, "unique", False)
     if foreign_key:
         args.append(ForeignKey(foreign_key))
     kwargs = {
@@ -442,18 +457,18 @@ def get_column_from_field(field: ModelField) -> Column:  # type: ignore
         "index": index,
         "unique": unique,
     }
-    sa_default = Undefined
-    if field.field_info.default_factory:
-        sa_default = field.field_info.default_factory
-    elif field.field_info.default is not Undefined:
-        sa_default = field.field_info.default
-    if sa_default is not Undefined:
+    sa_default = PydanticUndefined
+    if field.default_factory:
+        sa_default = field.default_factory
+    elif field.default is not PydanticUndefined:
+        sa_default = field.default
+    if sa_default is not PydanticUndefined:
         kwargs["default"] = sa_default
-    sa_column_args = getattr(field.field_info, "sa_column_args", Undefined)
-    if sa_column_args is not Undefined:
+    sa_column_args = getattr(field, "sa_column_args", PydanticUndefined)
+    if sa_column_args is not PydanticUndefined:
         args.extend(list(cast(Sequence[Any], sa_column_args)))
-    sa_column_kwargs = getattr(field.field_info, "sa_column_kwargs", Undefined)
-    if sa_column_kwargs is not Undefined:
+    sa_column_kwargs = getattr(field, "sa_column_kwargs", PydanticUndefined)
+    if sa_column_kwargs is not PydanticUndefined:
         kwargs.update(cast(Dict[Any, Any], sa_column_kwargs))
     return Column(sa_type, *args, **kwargs)  # type: ignore
 
@@ -462,13 +477,6 @@ class_registry = weakref.WeakValueDictionary()  # type: ignore
 
 default_registry = registry()
 
-
-def _value_items_is_true(v: Any) -> bool:
-    # Re-implement Pydantic's ValueItems.is_true() as it hasn't been released as of
-    # the current latest, Pydantic 1.8.2
-    return v is True or v is ...
-
-
 _TSQLModel = TypeVar("_TSQLModel", bound="SQLModel")
 
 
@@ -476,43 +484,17 @@ class SQLModel(BaseModel, metaclass=SQLModelMetaclass, registry=default_registry
     # SQLAlchemy needs to set weakref(s), Pydantic will set the other slots values
     __slots__ = ("__weakref__",)
     __tablename__: ClassVar[Union[str, Callable[..., str]]]
-    __sqlmodel_relationships__: ClassVar[Dict[str, RelationshipProperty]]  # type: ignore
+    __sqlmodel_relationships__: ClassVar[Dict[str, RelationshipProperty]]
     __name__: ClassVar[str]
     metadata: ClassVar[MetaData]
     __allow_unmapped__ = True  # https://docs.sqlalchemy.org/en/20/changelog/migration_20.html#migration-20-step-six
-
-    class Config:
-        orm_mode = True
-
-    def __new__(cls, *args: Any, **kwargs: Any) -> Any:
-        new_object = super().__new__(cls)
-        # SQLAlchemy doesn't call __init__ on the base class
-        # Ref: https://docs.sqlalchemy.org/en/14/orm/constructors.html
-        # Set __fields_set__ here, that would have been set when calling __init__
-        # in the Pydantic model so that when SQLAlchemy sets attributes that are
-        # added (e.g. when querying from DB) to the __fields_set__, this already exists
-        object.__setattr__(new_object, "__fields_set__", set())
-        return new_object
+    model_config = SQLModelConfig(from_attributes=True)
 
     def __init__(__pydantic_self__, **data: Any) -> None:
-        # Uses something other than `self` the first arg to allow "self" as a
-        # settable attribute
-        values, fields_set, validation_error = validate_model(
-            __pydantic_self__.__class__, data
-        )
-        # Only raise errors if not a SQLModel model
-        if (
-            not getattr(__pydantic_self__.__config__, "table", False)
-            and validation_error
-        ):
-            raise validation_error
-        # Do not set values as in Pydantic, pass them through setattr, so SQLAlchemy
-        # can handle them
-        # object.__setattr__(__pydantic_self__, '__dict__', values)
-        for key, value in values.items():
-            setattr(__pydantic_self__, key, value)
-        object.__setattr__(__pydantic_self__, "__fields_set__", fields_set)
-        non_pydantic_keys = data.keys() - values.keys()
+        old_dict = __pydantic_self__.__dict__.copy()
+        super().__init__(**data)
+        __pydantic_self__.__dict__ = old_dict | __pydantic_self__.__dict__
+        non_pydantic_keys = data.keys() - __pydantic_self__.model_fields
         for key in non_pydantic_keys:
             if key in __pydantic_self__.__sqlmodel_relationships__:
                 setattr(__pydantic_self__, key, data[key])
@@ -523,135 +505,36 @@ class SQLModel(BaseModel, metaclass=SQLModelMetaclass, registry=default_registry
             return
         else:
             # Set in SQLAlchemy, before Pydantic to trigger events and updates
-            if getattr(self.__config__, "table", False) and is_instrumented(self, name):  # type: ignore
+            if self.model_config.get("table", False) and is_instrumented(self, name):
                 set_attribute(self, name, value)
             # Set in Pydantic model to trigger possible validation changes, only for
             # non relationship values
             if name not in self.__sqlmodel_relationships__:
-                super().__setattr__(name, value)
-
-    @classmethod
-    def from_orm(
-        cls: Type[_TSQLModel], obj: Any, update: Optional[Dict[str, Any]] = None
-    ) -> _TSQLModel:
-        # Duplicated from Pydantic
-        if not cls.__config__.orm_mode:
-            raise ConfigError(
-                "You must have the config attribute orm_mode=True to use from_orm"
-            )
-        obj = {ROOT_KEY: obj} if cls.__custom_root_type__ else cls._decompose_class(obj)
-        # SQLModel, support update dict
-        if update is not None:
-            obj = {**obj, **update}
-        # End SQLModel support dict
-        if not getattr(cls.__config__, "table", False):
-            # If not table, normal Pydantic code
-            m: _TSQLModel = cls.__new__(cls)
-        else:
-            # If table, create the new instance normally to make SQLAlchemy create
-            # the _sa_instance_state attribute
-            m = cls()
-        values, fields_set, validation_error = validate_model(cls, obj)
-        if validation_error:
-            raise validation_error
-        # Updated to trigger SQLAlchemy internal handling
-        if not getattr(cls.__config__, "table", False):
-            object.__setattr__(m, "__dict__", values)
-        else:
-            for key, value in values.items():
-                setattr(m, key, value)
-        # Continue with standard Pydantic logic
-        object.__setattr__(m, "__fields_set__", fields_set)
-        m._init_private_attributes()
-        return m
-
-    @classmethod
-    def parse_obj(
-        cls: Type[_TSQLModel], obj: Any, update: Optional[Dict[str, Any]] = None
-    ) -> _TSQLModel:
-        obj = cls._enforce_dict_if_root(obj)
-        # SQLModel, support update dict
-        if update is not None:
-            obj = {**obj, **update}
-        # End SQLModel support dict
-        return super().parse_obj(obj)
+                super(SQLModel, self).__setattr__(name, value)
 
     def __repr_args__(self) -> Sequence[Tuple[Optional[str], Any]]:
         # Don't show SQLAlchemy private attributes
         return [(k, v) for k, v in self.__dict__.items() if not k.startswith("_sa_")]
 
-    # From Pydantic, override to enforce validation with dict
-    @classmethod
-    def validate(cls: Type[_TSQLModel], value: Any) -> _TSQLModel:
-        if isinstance(value, cls):
-            return value.copy() if cls.__config__.copy_on_model_validation else value
-
-        value = cls._enforce_dict_if_root(value)
-        if isinstance(value, dict):
-            values, fields_set, validation_error = validate_model(cls, value)
-            if validation_error:
-                raise validation_error
-            model = cls(**value)
-            # Reset fields set, this would have been done in Pydantic in __init__
-            object.__setattr__(model, "__fields_set__", fields_set)
-            return model
-        elif cls.__config__.orm_mode:
-            return cls.from_orm(value)
-        elif cls.__custom_root_type__:
-            return cls.parse_obj(value)
-        else:
-            try:
-                value_as_dict = dict(value)
-            except (TypeError, ValueError) as e:
-                raise DictError() from e
-            return cls(**value_as_dict)
-
-    # From Pydantic, override to only show keys from fields, omit SQLAlchemy attributes
-    def _calculate_keys(
-        self,
-        include: Optional[Mapping[Union[int, str], Any]],
-        exclude: Optional[Mapping[Union[int, str], Any]],
-        exclude_unset: bool,
-        update: Optional[Dict[str, Any]] = None,
-    ) -> Optional[AbstractSet[str]]:
-        if include is None and exclude is None and not exclude_unset:
-            # Original in Pydantic:
-            # return None
-            # Updated to not return SQLAlchemy attributes
-            # Do not include relationships as that would easily lead to infinite
-            # recursion, or traversing the whole database
-            return self.__fields__.keys()  # | self.__sqlmodel_relationships__.keys()
-
-        keys: AbstractSet[str]
-        if exclude_unset:
-            keys = self.__fields_set__.copy()
-        else:
-            # Original in Pydantic:
-            # keys = self.__dict__.keys()
-            # Updated to not return SQLAlchemy attributes
-            # Do not include relationships as that would easily lead to infinite
-            # recursion, or traversing the whole database
-            keys = self.__fields__.keys()  # | self.__sqlmodel_relationships__.keys()
-        if include is not None:
-            keys &= include.keys()
-
-        if update:
-            keys -= update.keys()
-
-        if exclude:
-            keys -= {k for k, v in exclude.items() if _value_items_is_true(v)}
-
-        return keys
 
     @declared_attr  # type: ignore
     def __tablename__(cls) -> str:
         return cls.__name__.lower()
 
 
-def _is_field_noneable(field: ModelField) -> bool:
-    if not field.required:
-        # Taken from [Pydantic](https://github.com/samuelcolvin/pydantic/blob/v1.8.2/pydantic/fields.py#L946-L947)
-        return field.allow_none and (
-            field.shape != SHAPE_SINGLETON or not field.sub_fields
-        )
+def _is_field_noneable(field: FieldInfo) -> bool:
+    if not field.is_required():
+        if field.annotation is None or field.annotation is type(None):
+            return True
+        if get_origin(field.annotation) is Union:
+            for base in get_args(field.annotation):
+                if base is type(None):
+                    return True
+        return False
     return False
+
+def _get_field_metadata(field: FieldInfo) -> object:
+    for meta in field.metadata:
+        if isinstance(meta, PydanticGeneralMetadata):
+            return meta
+    return object()

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -29,9 +29,8 @@ from typing import (
 )
 
 import pydantic
-from annotated_types import MaxLen
+from annotated_types import MaxLen, BaseMetadata
 from pydantic import BaseModel, EmailStr, ImportString, NameEmail
-from pydantic._internal._fields import PydanticGeneralMetadata
 from pydantic._internal._model_construction import ModelMetaclass
 from pydantic._internal._repr import Representation
 from pydantic.fields import FieldInfo as PydanticFieldInfo
@@ -705,7 +704,7 @@ def _is_field_noneable(field: FieldInfo) -> bool:
 
 def _get_field_metadata(field: FieldInfo) -> object:
     for meta in field.metadata:
-        if isinstance(meta, PydanticGeneralMetadata):
+        if isinstance(meta, BaseMetadata):
             return meta
         if isinstance(meta, MaxLen):
             return meta

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -384,10 +384,12 @@ class SQLModelMetaclass(ModelMetaclass, DeclarativeMeta):
         # triggers an error
         base_is_table = False
         for base in bases:
-            config = getattr(base, "model_config")
-            if config and getattr(config, "table", False):
-                base_is_table = True
-                break
+            # NOTE: SQLAlchemy mixins like AwaitableAttrs will not have a model_config
+            if hasattr(base, "model_config"):
+                config = getattr(base, "model_config")
+                if config and getattr(config, "table", False):
+                    base_is_table = True
+                    break
         if cls.model_config.get("table", False) and not base_is_table:
             dict_used = dict_.copy()
             for field_name, field_value in cls.model_fields.items():

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -273,7 +273,9 @@ class SQLModelMetaclass(ModelMetaclass, DeclarativeMeta):
             key: pydantic_kwargs.pop(key)
             for key in pydantic_kwargs.keys() & allowed_config_kwargs
         }
-        config_table = getattr(class_dict.get("Config", object()), "table", False) or kwargs.get("table", False)
+        config_table = getattr(
+            class_dict.get("Config", object()), "table", False
+        ) or kwargs.get("table", False)
         # If we have a table, we need to have defaults for all fields
         # Pydantic v2 sets a __pydantic_core_schema__ which is very hard to change. Changing the fields does not do anything
         if config_table is True:
@@ -282,7 +284,12 @@ class SQLModelMetaclass(ModelMetaclass, DeclarativeMeta):
                 if value is PydanticUndefined:
                     dict_used[key] = None
                 elif isinstance(value, FieldInfo):
-                    if value.default is PydanticUndefined and value.default_factory is None:
+                    if (
+                        value.default in (PydanticUndefined, Ellipsis)
+                    ) and value.default_factory is None:
+                        value.original_default = (
+                            value.default
+                        )  # So we can check for nullable
                         value.default = None
 
         new_cls: Type["SQLModelMetaclass"] = super().__new__(
@@ -496,6 +503,7 @@ def get_column_from_field(field: FieldInfo) -> Column:  # type: ignore
 class_registry = weakref.WeakValueDictionary()  # type: ignore
 
 default_registry = registry()
+_TSQLModel = TypeVar("_TSQLModel", bound="SQLModel")
 
 
 class SQLModel(BaseModel, metaclass=SQLModelMetaclass, registry=default_registry):
@@ -549,12 +557,28 @@ class SQLModel(BaseModel, metaclass=SQLModelMetaclass, registry=default_registry
         return cls.__name__.lower()
 
     @classmethod
-    def model_validate(cls, *args, **kwargs):
-        return super().model_validate(*args, **kwargs)
+    def model_validate(
+        cls: type[_TSQLModel],
+        obj: Any,
+        *,
+        strict: bool | None = None,
+        from_attributes: bool | None = None,
+        context: dict[str, Any] | None = None,
+    ) -> _TSQLModel:
+        # Somehow model validate doesn't call __init__ so it would remove our init logic
+        validated = super().model_validate(
+            obj, strict=strict, from_attributes=from_attributes, context=context
+        )
+        return cls(**{key: value for key, value in validated})
 
 
 def _is_field_noneable(field: FieldInfo) -> bool:
+    if getattr(field, "nullable", PydanticUndefined) is not PydanticUndefined:
+        return field.nullable
     if not field.is_required():
+        default = getattr(field, "original_default", field.default)
+        if default is PydanticUndefined:
+            return False
         if field.annotation is None or field.annotation is NoneType:
             return True
         if get_origin(field.annotation) is Union:

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -14,7 +14,6 @@ from typing import (
     ForwardRef,
     List,
     Mapping,
-    NoneType,
     Optional,
     Sequence,
     Set,
@@ -48,6 +47,7 @@ from .typing import SQLModelConfig
 
 _T = TypeVar("_T")
 NoArgAnyCallable = Callable[[], Any]
+NoneType = type(None)
 
 
 def __dataclass_transform__(
@@ -273,13 +273,17 @@ class SQLModelMetaclass(ModelMetaclass, DeclarativeMeta):
             key: pydantic_kwargs.pop(key)
             for key in pydantic_kwargs.keys() & allowed_config_kwargs
         }
-        config_table = getattr(class_dict.get("Config", object()), "table", False)
+        config_table = getattr(class_dict.get("Config", object()), "table", False) or kwargs.get("table", False)
         # If we have a table, we need to have defaults for all fields
         # Pydantic v2 sets a __pydantic_core_schema__ which is very hard to change. Changing the fields does not do anything
         if config_table is True:
-            for key in original_annotations.keys():
-                if dict_used.get(key, PydanticUndefined) is PydanticUndefined:
+            for key in pydantic_annotations.keys():
+                value = dict_used.get(key, PydanticUndefined)
+                if value is PydanticUndefined:
                     dict_used[key] = None
+                elif isinstance(value, FieldInfo):
+                    if value.default is PydanticUndefined and value.default_factory is None:
+                        value.default = None
 
         new_cls: Type["SQLModelMetaclass"] = super().__new__(
             cls, name, bases, dict_used, **config_kwargs
@@ -349,8 +353,11 @@ class SQLModelMetaclass(ModelMetaclass, DeclarativeMeta):
                     continue
                 ann = cls.__annotations__[rel_name]
                 relationship_to = get_origin(ann)
-                # If Union (Optional), get the real field
-                if relationship_to is Union:
+                # Direct relationships (e.g. 'Team' or Team) have None as an origin
+                if relationship_to is None:
+                    relationship_to = ann
+                # If Union (e.g. Optional), get the real field
+                elif relationship_to is Union:
                     relationship_to = get_args(ann)[0]
                 # If a list, then also get the real field
                 elif relationship_to is list:
@@ -501,6 +508,16 @@ class SQLModel(BaseModel, metaclass=SQLModelMetaclass, registry=default_registry
     __allow_unmapped__ = True  # https://docs.sqlalchemy.org/en/20/changelog/migration_20.html#migration-20-step-six
     model_config = SQLModelConfig(from_attributes=True)
 
+    def __new__(cls, *args: Any, **kwargs: Any) -> Any:
+        new_object = super().__new__(cls)
+        # SQLAlchemy doesn't call __init__ on the base class
+        # Ref: https://docs.sqlalchemy.org/en/14/orm/constructors.html
+        # Set __fields_set__ here, that would have been set when calling __init__
+        # in the Pydantic model so that when SQLAlchemy sets attributes that are
+        # added (e.g. when querying from DB) to the __fields_set__, this already exists
+        object.__setattr__(new_object, "__pydantic_fields_set__", set())
+        return new_object
+
     def __init__(__pydantic_self__, **data: Any) -> None:
         old_dict = __pydantic_self__.__dict__.copy()
         super().__init__(**data)
@@ -530,6 +547,10 @@ class SQLModel(BaseModel, metaclass=SQLModelMetaclass, registry=default_registry
     @declared_attr  # type: ignore
     def __tablename__(cls) -> str:
         return cls.__name__.lower()
+
+    @classmethod
+    def model_validate(cls, *args, **kwargs):
+        return super().model_validate(*args, **kwargs)
 
 
 def _is_field_noneable(field: FieldInfo) -> bool:

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -596,6 +596,10 @@ class SQLModel(BaseModel, metaclass=SQLModelMetaclass, registry=default_registry
         # in the Pydantic model so that when SQLAlchemy sets attributes that are
         # added (e.g. when querying from DB) to the __fields_set__, this already exists
         object.__setattr__(new_object, "__pydantic_fields_set__", set())
+        if not hasattr(new_object, "__pydantic_extra__"):
+            object.__setattr__(new_object, "__pydantic_extra__", None)
+        if not hasattr(new_object, "__pydantic_private__"):
+            object.__setattr__(new_object, "__pydantic_private__", None)
         return new_object
 
     def __init__(__pydantic_self__, **data: Any) -> None:

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -666,14 +666,15 @@ def _is_field_noneable(field: FieldInfo) -> bool:
         return field.nullable
     if not field.is_required():
         default = getattr(field, "original_default", field.default)
+        if default is PydanticUndefined:
+            return False
         if field.annotation is None or field.annotation is NoneType:
             return True
         if _is_optional_or_union(field.annotation):
             for base in get_args(field.annotation):
                 if base is NoneType:
                     return True
-        if default is PydanticUndefined:
-            return False
+
         return False
     return False
 

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ipaddress
 import sys
+import types
 import uuid
 import weakref
 from datetime import date, datetime, time, timedelta
@@ -26,7 +27,6 @@ from typing import (
     Union,
     cast,
 )
-import types
 
 import pydantic
 from pydantic import BaseModel
@@ -43,10 +43,9 @@ from sqlalchemy.orm.attributes import set_attribute
 from sqlalchemy.orm.decl_api import DeclarativeMeta
 from sqlalchemy.orm.instrumentation import is_instrumented
 from sqlalchemy.orm.properties import MappedColumn
-from sqlalchemy.sql.schema import MetaData, DefaultClause
-from sqlalchemy.sql.sqltypes import LargeBinary, Time
 from sqlalchemy.sql import false, true
-
+from sqlalchemy.sql.schema import DefaultClause, MetaData
+from sqlalchemy.sql.sqltypes import LargeBinary, Time
 
 from .sql.sqltypes import GUID, AutoString
 from .typing import SQLModelConfig

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -524,6 +524,8 @@ def get_column_from_field(field: FieldInfo) -> Column:  # type: ignore
         return sa_column
     if isinstance(sa_column, MappedColumn):
         return sa_column.column
+    if isinstance(sa_column, types.FunctionType):
+        return sa_column()
     sa_type = get_sqlalchemy_type(field)
     primary_key = getattr(field, "primary_key", False)
     index = getattr(field, "index", PydanticUndefined)

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -61,6 +61,9 @@ def __dataclass_transform__(
 
 
 class FieldInfo(PydanticFieldInfo):
+
+    nullable: Union[bool, PydanticUndefinedType]
+
     def __init__(self, default: Any = PydanticUndefined, **kwargs: Any) -> None:
         primary_key = kwargs.pop("primary_key", False)
         nullable = kwargs.pop("nullable", PydanticUndefined)
@@ -587,7 +590,7 @@ class SQLModel(BaseModel, metaclass=SQLModelMetaclass, registry=default_registry
 
 
 def _is_field_noneable(field: FieldInfo) -> bool:
-    if getattr(field, "nullable", PydanticUndefined) is not PydanticUndefined:
+    if not isinstance(field.nullable, PydanticUndefinedType):
         return field.nullable
     if not field.is_required():
         default = getattr(field, "original_default", field.default)

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -448,7 +448,7 @@ def _is_optional_or_union(type_: Optional[type]) -> bool:
 
 
 def get_sqlalchemy_type(field: FieldInfo) -> Any:
-    type_: Optional[type] = field.annotation
+    type_: Optional[type] | _AnnotatedAlias = field.annotation
 
     # Resolve Optional/Union fields
 
@@ -473,7 +473,7 @@ def get_sqlalchemy_type(field: FieldInfo) -> Any:
         if type2 is pydantic.AnyUrl:
             meta = get_args(type_)[1]
             return AutoString(length=meta.max_length)
-    elif org_type is pydantic.AnyUrl:
+    elif org_type is pydantic.AnyUrl and type(type_) is _AnnotatedAlias:
         return AutoString(type_.__metadata__[0].max_length)
 
     # The 3rd is PydanticGeneralMetadata

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -666,9 +666,7 @@ def _is_field_noneable(field: FieldInfo) -> bool:
         return field.nullable
     if not field.is_required():
         default = getattr(field, "original_default", field.default)
-        if default is None:
-            return True
-        elif default is PydanticUndefined:
+        if default is PydanticUndefined:
             return False
         if field.annotation is None or field.annotation is NoneType:
             return True

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -461,8 +461,11 @@ def get_sqlalchemy_type(field: FieldInfo) -> Any:
     # UrlConstraints(max_length=512,
     # allowed_schemes=['smb', 'ftp', 'file']) ]
     if type_ is pydantic.AnyUrl:
-        meta = field.metadata[0]
-        return AutoString(length=meta.max_length)
+        if field.metadata:
+            meta = field.metadata[0]
+            return AutoString(length=meta.max_length)
+        else:
+            return AutoString
 
     org_type = get_origin(type_)
     if org_type is Annotated:

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -668,7 +668,7 @@ def _is_field_noneable(field: FieldInfo) -> bool:
         default = getattr(field, "original_default", field.default)
         if default is None:
             return True
-        elif default is not PydanticUndefined:
+        elif default is PydanticUndefined:
             return False
         if field.annotation is None or field.annotation is NoneType:
             return True

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -29,7 +29,8 @@ from typing import (
 )
 
 import pydantic
-from pydantic import BaseModel
+from annotated_types import MaxLen
+from pydantic import BaseModel, EmailStr, ImportString, NameEmail
 from pydantic._internal._fields import PydanticGeneralMetadata
 from pydantic._internal._model_construction import ModelMetaclass
 from pydantic._internal._repr import Representation
@@ -480,7 +481,7 @@ def get_sqlalchemy_type(field: FieldInfo) -> Any:
     metadata = _get_field_metadata(field)
     if type_ is None:
         raise ValueError("Missing field type")
-    if issubclass(type_, str):
+    if issubclass(type_, str) or type_ in (EmailStr, NameEmail, ImportString):
         max_length = getattr(metadata, "max_length", None)
         if max_length:
             return AutoString(length=max_length)
@@ -692,5 +693,7 @@ def _is_field_noneable(field: FieldInfo) -> bool:
 def _get_field_metadata(field: FieldInfo) -> object:
     for meta in field.metadata:
         if isinstance(meta, PydanticGeneralMetadata):
+            return meta
+        if isinstance(meta, MaxLen):
             return meta
     return object()

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -55,10 +55,7 @@ if sys.version_info >= (3, 8):
 else:
     from typing_extensions import get_args, get_origin
 
-if sys.version_info >= (3, 9):
-    from typing import Annotated, _AnnotatedAlias
-else:
-    from typing_extensions import Annotated, _AnnotatedAlias
+from typing_extensions import Annotated, _AnnotatedAlias
 
 _T = TypeVar("_T")
 NoArgAnyCallable = Callable[[], Any]

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -479,6 +479,7 @@ class SQLModel(BaseModel, metaclass=SQLModelMetaclass, registry=default_registry
     __sqlmodel_relationships__: ClassVar[Dict[str, RelationshipProperty]]  # type: ignore
     __name__: ClassVar[str]
     metadata: ClassVar[MetaData]
+    __allow_unmapped__ = True # https://docs.sqlalchemy.org/en/20/changelog/migration_20.html#migration-20-step-six
 
     class Config:
         orm_mode = True

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -24,8 +24,7 @@ from typing import (
     Type,
     TypeVar,
     Union,
-    cast,
-    get_args
+    cast
 )
 import types
 
@@ -46,6 +45,8 @@ from sqlalchemy.orm.instrumentation import is_instrumented
 from sqlalchemy.orm.properties import MappedColumn
 from sqlalchemy.sql.schema import MetaData, DefaultClause
 from sqlalchemy.sql.sqltypes import LargeBinary, Time
+from sqlalchemy.sql import false, true
+
 
 from .sql.sqltypes import GUID, AutoString
 from .typing import SQLModelConfig
@@ -179,8 +180,19 @@ def Field(
         #server_default -> default
         if isinstance(sa_column_, Column) and isinstance(sa_column_.server_default, DefaultClause):
             default_value =  sa_column_.server_default.arg
-            if issubclass( type(sa_column_.type), Integer):
+            if issubclass( type(sa_column_.type), Integer) and isinstance(default_value, str):
                 default = int(default_value)
+            elif issubclass( type(sa_column_.type), Boolean):
+                if default_value is false():
+                    default = False
+                elif default_value is true():
+                    default = True
+                elif isinstance(default_value, str):
+                    if default_value == '1':
+                        default =True
+                    elif default_value == '0':
+                        default = False
+                    
 
     field_info = FieldInfo(
         default,

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -177,7 +177,7 @@ def Field(
 ) -> Any:
     current_schema_extra = schema_extra or {}
     if default is PydanticUndefined:
-        if type(sa_column) is types.FunctionType: #lambda 
+        if isinstance(sa_column, types.FunctionType): #lambda 
             sa_column_ = sa_column()
         else:
             sa_column_ = sa_column

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -10,7 +10,7 @@ from enum import Enum
 from pathlib import Path
 from typing import (
     AbstractSet,
-    Any, 
+    Any,
     Callable,
     ClassVar,
     Dict,
@@ -24,7 +24,7 @@ from typing import (
     Type,
     TypeVar,
     Union,
-    cast
+    cast,
 )
 import types
 
@@ -55,7 +55,7 @@ if sys.version_info >= (3, 8):
     from typing import get_args, get_origin
 else:
     from typing_extensions import get_args, get_origin
-    
+
 if sys.version_info >= (3, 9):
     from typing import Annotated
 else:
@@ -177,27 +177,30 @@ def Field(
 ) -> Any:
     current_schema_extra = schema_extra or {}
     if default is PydanticUndefined:
-        if isinstance(sa_column, types.FunctionType): #lambda 
+        if isinstance(sa_column, types.FunctionType):  # lambda
             sa_column_ = sa_column()
         else:
             sa_column_ = sa_column
-            
-        #server_default -> default
-        if isinstance(sa_column_, Column) and isinstance(sa_column_.server_default, DefaultClause):
-            default_value =  sa_column_.server_default.arg
-            if issubclass( type(sa_column_.type), Integer) and isinstance(default_value, str):
+
+        # server_default -> default
+        if isinstance(sa_column_, Column) and isinstance(
+            sa_column_.server_default, DefaultClause
+        ):
+            default_value = sa_column_.server_default.arg
+            if issubclass(type(sa_column_.type), Integer) and isinstance(
+                default_value, str
+            ):
                 default = int(default_value)
-            elif issubclass( type(sa_column_.type), Boolean):
+            elif issubclass(type(sa_column_.type), Boolean):
                 if default_value is false():
                     default = False
                 elif default_value is true():
                     default = True
                 elif isinstance(default_value, str):
-                    if default_value == '1':
-                        default =True
-                    elif default_value == '0':
+                    if default_value == "1":
+                        default = True
+                    elif default_value == "0":
                         default = False
-                    
 
     field_info = FieldInfo(
         default,
@@ -447,6 +450,7 @@ def get_sqlalchemy_type(field: FieldInfo) -> Any:
             return get_origin(type_) in (types.UnionType, Union)
         else:
             return get_origin(type_) is Union
+
     if type_ is not None and is_optional_or_union(type_):
         bases = get_args(type_)
         if len(bases) > 2:
@@ -455,17 +459,17 @@ def get_sqlalchemy_type(field: FieldInfo) -> Any:
             )
         type_ = bases[0]
     # Resolve Annoted fields,
-    # like typing.Annotated[pydantic_core._pydantic_core.Url, 
-    # UrlConstraints(max_length=512, 
+    # like typing.Annotated[pydantic_core._pydantic_core.Url,
+    # UrlConstraints(max_length=512,
     # allowed_schemes=['smb', 'ftp', 'file']) ]
     if type_ is pydantic.AnyUrl:
-        meta =  field.metadata[0]
+        meta = field.metadata[0]
         return AutoString(length=meta.max_length)
-    
-    if  get_origin(type_) is Annotated:
+
+    if get_origin(type_) is Annotated:
         type2 = get_args(type_)[0]
         if type2 is pydantic.AnyUrl:
-            meta =  get_args(type_)[1]
+            meta = get_args(type_)[1]
             return AutoString(length=meta.max_length)
 
     # The 3rd is PydanticGeneralMetadata

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -467,11 +467,14 @@ def get_sqlalchemy_type(field: FieldInfo) -> Any:
         meta = field.metadata[0]
         return AutoString(length=meta.max_length)
 
-    if get_origin(type_) is Annotated:
+    org_type = get_origin(type_)
+    if org_type is Annotated:
         type2 = get_args(type_)[0]
         if type2 is pydantic.AnyUrl:
             meta = get_args(type_)[1]
             return AutoString(length=meta.max_length)
+    elif org_type is pydantic.AnyUrl:
+        return AutoString(type_.__metadata__[0].max_length)
 
     # The 3rd is PydanticGeneralMetadata
     metadata = _get_field_metadata(field)

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -167,7 +167,7 @@ def Field(
     unique: bool = False,
     nullable: Union[bool, PydanticUndefinedType] = PydanticUndefined,
     index: Union[bool, PydanticUndefinedType] = PydanticUndefined,
-    sa_column: Union[Column, PydanticUndefinedType, types.FunctionType] = PydanticUndefined,  # type: ignore
+    sa_column: Union[Column, PydanticUndefinedType, Callable[[], Column]] = PydanticUndefined,  # type: ignore
     sa_column_args: Union[Sequence[Any], PydanticUndefinedType] = PydanticUndefined,
     sa_column_kwargs: Union[
         Mapping[str, Any], PydanticUndefinedType
@@ -525,7 +525,9 @@ def get_column_from_field(field: FieldInfo) -> Column:  # type: ignore
     if isinstance(sa_column, MappedColumn):
         return sa_column.column
     if isinstance(sa_column, types.FunctionType):
-        return sa_column()
+        col = sa_column()
+        assert isinstance(col, Column)
+        return col
     sa_type = get_sqlalchemy_type(field)
     primary_key = getattr(field, "primary_key", False)
     index = getattr(field, "index", PydanticUndefined)

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -525,23 +525,14 @@ def get_column_from_field(field: FieldInfo) -> Column:  # type: ignore
     sa_column > field attributes > annotation info
     """
     sa_column = getattr(field, "sa_column", PydanticUndefined)
-    col: Column | None = None
     if isinstance(sa_column, Column):
-        col = sa_column
-    elif isinstance(sa_column, MappedColumn):
-        col = sa_column.column
-    elif isinstance(sa_column, types.FunctionType):
+        return sa_column
+    if isinstance(sa_column, MappedColumn):
+        return sa_column.column
+    if isinstance(sa_column, types.FunctionType):
         col = sa_column()
-    if isinstance(col, Column):
-        # field attribute or field annotation -> Column.nullable
-        if col.nullable is PydanticUndefined:
-            col.nullable = _is_field_noneable(field)
-        # field.primary_key -> Column.primary_key
-        if col.primary_key is PydanticUndefined:
-            primary_key = getattr(field, "primary_key", False)
-            col.primary_key = primary_key
+        assert isinstance(col, Column)
         return col
-
     sa_type = get_sqlalchemy_type(field)
     primary_key = getattr(field, "primary_key", False)
     index = getattr(field, "index", PydanticUndefined)

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -56,7 +56,7 @@ else:
     from typing_extensions import get_args, get_origin
 
 if sys.version_info >= (3, 9):
-    from typing import Annotated
+    from typing import Annotated, _AnnotatedAlias
 else:
     from typing_extensions import Annotated, _AnnotatedAlias
 

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -479,7 +479,7 @@ class SQLModel(BaseModel, metaclass=SQLModelMetaclass, registry=default_registry
     __sqlmodel_relationships__: ClassVar[Dict[str, RelationshipProperty]]  # type: ignore
     __name__: ClassVar[str]
     metadata: ClassVar[MetaData]
-    __allow_unmapped__ = True # https://docs.sqlalchemy.org/en/20/changelog/migration_20.html#migration-20-step-six
+    __allow_unmapped__ = True  # https://docs.sqlalchemy.org/en/20/changelog/migration_20.html#migration-20-step-six
 
     class Config:
         orm_mode = True
@@ -523,7 +523,7 @@ class SQLModel(BaseModel, metaclass=SQLModelMetaclass, registry=default_registry
             return
         else:
             # Set in SQLAlchemy, before Pydantic to trigger events and updates
-            if getattr(self.__config__, "table", False) and is_instrumented(self, name):
+            if getattr(self.__config__, "table", False) and is_instrumented(self, name):  # type: ignore
                 set_attribute(self, name, value)
             # Set in Pydantic model to trigger possible validation changes, only for
             # non relationship values

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -649,7 +649,10 @@ class SQLModel(BaseModel, metaclass=SQLModelMetaclass, registry=default_registry
         # remove defaults so they don't get validated
         data = {}
         for key, value in validated:
-            field = cls.model_fields[key]
+            field = cls.model_fields.get(key)
+
+            if field is None:
+                continue
 
             if (
                 hasattr(field, "default")

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -666,15 +666,14 @@ def _is_field_noneable(field: FieldInfo) -> bool:
         return field.nullable
     if not field.is_required():
         default = getattr(field, "original_default", field.default)
-        if default is PydanticUndefined:
-            return False
         if field.annotation is None or field.annotation is NoneType:
             return True
         if _is_optional_or_union(field.annotation):
             for base in get_args(field.annotation):
                 if base is NoneType:
                     return True
-
+        if default is PydanticUndefined:
+            return False
         return False
     return False
 

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -442,7 +442,7 @@ def get_sqlalchemy_type(field: FieldInfo) -> Any:
     type_: Optional[type] = field.annotation
 
     # Resolve Optional/Union fields
-    def is_optional_or_union(type_):
+    def is_optional_or_union(type_: Optional[type]) -> bool:
         if sys.version_info >= (3, 10):
             return get_origin(type_) in (types.UnionType, Union)
         else:

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -58,7 +58,7 @@ else:
 if sys.version_info >= (3, 9):
     from typing import Annotated
 else:
-    from typing_extensions import Annotated
+    from typing_extensions import Annotated, _AnnotatedAlias
 
 _T = TypeVar("_T")
 NoArgAnyCallable = Callable[[], Any]

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -474,6 +474,7 @@ def get_sqlalchemy_type(field: FieldInfo) -> Any:
         if type2 is pydantic.AnyUrl:
             meta = get_args(type_)[1]
             return AutoString(length=meta.max_length)
+        type_ = type2
     elif org_type is pydantic.AnyUrl and type(type_) is _AnnotatedAlias:
         return AutoString(type_.__metadata__[0].max_length)
 

--- a/sqlmodel/orm/session.py
+++ b/sqlmodel/orm/session.py
@@ -14,6 +14,7 @@ from sqlalchemy import util
 from sqlalchemy.orm import Query as _Query
 from sqlalchemy.orm import Session as _Session
 from sqlalchemy.sql.base import Executable as _Executable
+from sqlalchemy.sql.selectable import ForUpdateArg as _ForUpdateArg
 from sqlmodel.sql.expression import Select, SelectOfScalar
 from typing_extensions import Literal
 
@@ -136,7 +137,7 @@ class Session(_Session):
         ident: Any,
         options: Optional[Sequence[Any]] = None,
         populate_existing: bool = False,
-        with_for_update: Optional[Union[Literal[True], Mapping[str, Any]]] = None,
+        with_for_update: Optional[_ForUpdateArg] = None,
         identity_token: Optional[Any] = None,
         execution_options: Mapping[Any, Any] = util.EMPTY_DICT,
     ) -> Optional[_TSelectParam]:

--- a/sqlmodel/orm/session.py
+++ b/sqlmodel/orm/session.py
@@ -1,4 +1,14 @@
-from typing import Any, Mapping, Optional, Sequence, Type, TypeVar, Union, overload
+from typing import (
+    Any,
+    Dict,
+    Mapping,
+    Optional,
+    Sequence,
+    Type,
+    TypeVar,
+    Union,
+    overload,
+)
 
 from sqlalchemy import util
 from sqlalchemy.orm import Query as _Query
@@ -21,7 +31,7 @@ class Session(_Session):
         *,
         params: Optional[Union[Mapping[str, Any], Sequence[Mapping[str, Any]]]] = None,
         execution_options: Mapping[str, Any] = util.EMPTY_DICT,
-        bind_arguments: Optional[Mapping[str, Any]] = None,
+        bind_arguments: Optional[Dict[str, Any]] = None,
         _parent_execute_state: Optional[Any] = None,
         _add_event: Optional[Any] = None,
         **kw: Any,
@@ -35,7 +45,7 @@ class Session(_Session):
         *,
         params: Optional[Union[Mapping[str, Any], Sequence[Mapping[str, Any]]]] = None,
         execution_options: Mapping[str, Any] = util.EMPTY_DICT,
-        bind_arguments: Optional[Mapping[str, Any]] = None,
+        bind_arguments: Optional[Dict[str, Any]] = None,
         _parent_execute_state: Optional[Any] = None,
         _add_event: Optional[Any] = None,
         **kw: Any,
@@ -52,7 +62,7 @@ class Session(_Session):
         *,
         params: Optional[Union[Mapping[str, Any], Sequence[Mapping[str, Any]]]] = None,
         execution_options: Mapping[str, Any] = util.EMPTY_DICT,
-        bind_arguments: Optional[Mapping[str, Any]] = None,
+        bind_arguments: Optional[Dict[str, Any]] = None,
         _parent_execute_state: Optional[Any] = None,
         _add_event: Optional[Any] = None,
         **kw: Any,
@@ -75,7 +85,7 @@ class Session(_Session):
         statement: _Executable,
         params: Optional[Union[Mapping[str, Any], Sequence[Mapping[str, Any]]]] = None,
         execution_options: Optional[Mapping[str, Any]] = util.EMPTY_DICT,
-        bind_arguments: Optional[Mapping[str, Any]] = None,
+        bind_arguments: Optional[Dict[str, Any]] = None,
         _parent_execute_state: Optional[Any] = None,
         _add_event: Optional[Any] = None,
         **kw: Any,

--- a/sqlmodel/orm/session.py
+++ b/sqlmodel/orm/session.py
@@ -11,6 +11,7 @@ from typing import (
 )
 
 from sqlalchemy import util
+from sqlalchemy.orm import Mapper as _Mapper
 from sqlalchemy.orm import Query as _Query
 from sqlalchemy.orm import Session as _Session
 from sqlalchemy.sql.base import Executable as _Executable
@@ -133,13 +134,14 @@ class Session(_Session):
 
     def get(
         self,
-        entity: Type[_TSelectParam],
+        entity: Union[Type[_TSelectParam], "_Mapper[_TSelectParam]"],
         ident: Any,
         options: Optional[Sequence[Any]] = None,
         populate_existing: bool = False,
         with_for_update: Optional[_ForUpdateArg] = None,
         identity_token: Optional[Any] = None,
         execution_options: Mapping[Any, Any] = util.EMPTY_DICT,
+        bind_arguments: Optional[Dict[str, Any]] = None,
     ) -> Optional[_TSelectParam]:
         return super().get(
             entity,
@@ -149,4 +151,5 @@ class Session(_Session):
             with_for_update=with_for_update,
             identity_token=identity_token,
             execution_options=execution_options,
+            bind_arguments=bind_arguments
         )

--- a/sqlmodel/orm/session.py
+++ b/sqlmodel/orm/session.py
@@ -17,7 +17,6 @@ from sqlalchemy.orm import Session as _Session
 from sqlalchemy.sql.base import Executable as _Executable
 from sqlalchemy.sql.selectable import ForUpdateArg as _ForUpdateArg
 from sqlmodel.sql.expression import Select, SelectOfScalar
-from typing_extensions import Literal
 
 from ..engine.result import Result, ScalarResult
 from ..sql.base import Executable
@@ -151,5 +150,5 @@ class Session(_Session):
             with_for_update=with_for_update,
             identity_token=identity_token,
             execution_options=execution_options,
-            bind_arguments=bind_arguments
+            bind_arguments=bind_arguments,
         )

--- a/sqlmodel/orm/session.py
+++ b/sqlmodel/orm/session.py
@@ -12,9 +12,7 @@ from typing import (
 
 from sqlalchemy import util
 from sqlalchemy.orm import Mapper as _Mapper
-from sqlalchemy.orm import Query as _Query
 from sqlalchemy.orm import Session as _Session
-from sqlalchemy.sql.base import Executable as _Executable
 from sqlalchemy.sql.selectable import ForUpdateArg as _ForUpdateArg
 from sqlmodel.sql.expression import Select, SelectOfScalar
 
@@ -81,56 +79,6 @@ class Session(_Session):
             return results.scalars()  # type: ignore
         return results  # type: ignore
 
-    def execute(
-        self,
-        statement: _Executable,
-        params: Optional[Union[Mapping[str, Any], Sequence[Mapping[str, Any]]]] = None,
-        execution_options: Mapping[str, Any] = util.EMPTY_DICT,
-        bind_arguments: Optional[Dict[str, Any]] = None,
-        _parent_execute_state: Optional[Any] = None,
-        _add_event: Optional[Any] = None,
-        **kw: Any,
-    ) -> Result[Any]:
-        """
-        🚨 You probably want to use `session.exec()` instead of `session.execute()`.
-
-        This is the original SQLAlchemy `session.execute()` method that returns objects
-        of type `Row`, and that you have to call `scalars()` to get the model objects.
-
-        For example:
-
-        ```Python
-        heroes = session.execute(select(Hero)).scalars().all()
-        ```
-
-        instead you could use `exec()`:
-
-        ```Python
-        heroes = session.exec(select(Hero)).all()
-        ```
-        """
-        return super().execute(  # type: ignore
-            statement,
-            params=params,
-            execution_options=execution_options,
-            bind_arguments=bind_arguments,
-            _parent_execute_state=_parent_execute_state,
-            _add_event=_add_event,
-            **kw,
-        )
-
-    def query(self, *entities: Any, **kwargs: Any) -> "_Query[Any]":
-        """
-        🚨 You probably want to use `session.exec()` instead of `session.query()`.
-
-        `session.exec()` is SQLModel's own short version with increased type
-        annotations.
-
-        Or otherwise you might want to use `session.execute()` instead of
-        `session.query()`.
-        """
-        return super().query(*entities, **kwargs)  # type: ignore
-
     def get(
         self,
         entity: Union[Type[_TSelectParam], "_Mapper[_TSelectParam]"],
@@ -152,3 +100,34 @@ class Session(_Session):
             execution_options=execution_options,
             bind_arguments=bind_arguments,
         )
+
+
+Session.query.__doc__ = """
+🚨 You probably want to use `session.exec()` instead of `session.query()`.
+
+`session.exec()` is SQLModel's own short version with increased type
+annotations.
+
+Or otherwise you might want to use `session.execute()` instead of
+`session.query()`.
+"""
+
+
+Session.execute.__doc__ = """
+🚨 You probably want to use `session.exec()` instead of `session.execute()`.
+
+This is the original SQLAlchemy `session.execute()` method that returns objects
+of type `Row`, and that you have to call `scalars()` to get the model objects.
+
+For example:
+
+```Python
+heroes = session.execute(select(Hero)).scalars().all()
+```
+
+instead you could use `exec()`:
+
+```Python
+heroes = session.exec(select(Hero)).all()
+```
+"""

--- a/sqlmodel/orm/session.py
+++ b/sqlmodel/orm/session.py
@@ -84,7 +84,7 @@ class Session(_Session):
         self,
         statement: _Executable,
         params: Optional[Union[Mapping[str, Any], Sequence[Mapping[str, Any]]]] = None,
-        execution_options: Optional[Mapping[str, Any]] = util.EMPTY_DICT,
+        execution_options: Mapping[str, Any] = util.EMPTY_DICT,
         bind_arguments: Optional[Dict[str, Any]] = None,
         _parent_execute_state: Optional[Any] = None,
         _add_event: Optional[Any] = None,

--- a/sqlmodel/orm/session.py
+++ b/sqlmodel/orm/session.py
@@ -138,7 +138,7 @@ class Session(_Session):
         populate_existing: bool = False,
         with_for_update: Optional[Union[Literal[True], Mapping[str, Any]]] = None,
         identity_token: Optional[Any] = None,
-        execution_options: Optional[Mapping[Any, Any]] = util.EMPTY_DICT,
+        execution_options: Mapping[Any, Any] = util.EMPTY_DICT,
     ) -> Optional[_TSelectParam]:
         return super().get(
             entity,

--- a/sqlmodel/orm/session.py
+++ b/sqlmodel/orm/session.py
@@ -118,7 +118,7 @@ class Session(_Session):
         Or otherwise you might want to use `session.execute()` instead of
         `session.query()`.
         """
-        return super().query(*entities, **kwargs)
+        return super().query(*entities, **kwargs)  # type: ignore
 
     def get(
         self,

--- a/sqlmodel/orm/session.py
+++ b/sqlmodel/orm/session.py
@@ -85,7 +85,7 @@ class Session(_Session):
         ident: Any,
         options: Optional[Sequence[Any]] = None,
         populate_existing: bool = False,
-        with_for_update: Optional[_ForUpdateArg] = None,
+        with_for_update: Union[_ForUpdateArg, None, bool, Dict[str, Any]] = None,
         identity_token: Optional[Any] = None,
         execution_options: Mapping[Any, Any] = util.EMPTY_DICT,
         bind_arguments: Optional[Dict[str, Any]] = None,

--- a/sqlmodel/sql/expression.py
+++ b/sqlmodel/sql/expression.py
@@ -35,6 +35,14 @@ class SelectOfScalar(_Select[Tuple[_TSelect]], Generic[_TSelect]):
     inherit_cache = True
 
 
+# This is not comparable to sqlalchemy.sql.selectable.ScalarSelect, that has a different
+# purpose. This is the same as a normal SQLAlchemy Select class where there's only one
+# entity, so the result will be converted to a scalar by default. This way writing
+# for loops on the results will feel natural.
+class SelectOfScalar(_Select, Generic[_TSelect]):
+    inherit_cache = True
+
+
 if TYPE_CHECKING:  # pragma: no cover
     from ..main import SQLModel
 

--- a/sqlmodel/sql/expression.py
+++ b/sqlmodel/sql/expression.py
@@ -406,4 +406,4 @@ def select(*entities: Any) -> Union[Select, SelectOfScalar]:  # type: ignore
 def col(column_expression: Any) -> ColumnClause:  # type: ignore
     if not isinstance(column_expression, (ColumnClause, Column, InstrumentedAttribute)):
         raise RuntimeError(f"Not a SQLAlchemy column: {column_expression}")
-    return column_expression
+    return column_expression  # type: ignore

--- a/sqlmodel/sql/expression.py
+++ b/sqlmodel/sql/expression.py
@@ -23,7 +23,7 @@ from sqlalchemy.sql.expression import Select as _Select
 _TSelect = TypeVar("_TSelect")
 
 
-class Select(_Select[_TSelect], Generic[_TSelect]):
+class Select(_Select[Tuple[_TSelect]], Generic[_TSelect]):
     inherit_cache = True
 
 
@@ -31,7 +31,7 @@ class Select(_Select[_TSelect], Generic[_TSelect]):
 # purpose. This is the same as a normal SQLAlchemy Select class where there's only one
 # entity, so the result will be converted to a scalar by default. This way writing
 # for loops on the results will feel natural.
-class SelectOfScalar(_Select, Generic[_TSelect]):
+class SelectOfScalar(_Select[Tuple[_TSelect]], Generic[_TSelect]):
     inherit_cache = True
 
 

--- a/sqlmodel/sql/expression.py
+++ b/sqlmodel/sql/expression.py
@@ -22,8 +22,7 @@ from sqlalchemy.sql.expression import Select as _Select
 
 _TSelect = TypeVar("_TSelect")
 
-
-class Select(_Select, Generic[_TSelect]):
+class Select(_Select[_TSelect], Generic[_TSelect]):
     inherit_cache = True
 
 

--- a/sqlmodel/sql/expression.py
+++ b/sqlmodel/sql/expression.py
@@ -35,14 +35,6 @@ class SelectOfScalar(_Select[Tuple[_TSelect]], Generic[_TSelect]):
     inherit_cache = True
 
 
-# This is not comparable to sqlalchemy.sql.selectable.ScalarSelect, that has a different
-# purpose. This is the same as a normal SQLAlchemy Select class where there's only one
-# entity, so the result will be converted to a scalar by default. This way writing
-# for loops on the results will feel natural.
-class SelectOfScalar(_Select, Generic[_TSelect]):
-    inherit_cache = True
-
-
 if TYPE_CHECKING:  # pragma: no cover
     from ..main import SQLModel
 

--- a/sqlmodel/sql/expression.py
+++ b/sqlmodel/sql/expression.py
@@ -22,6 +22,7 @@ from sqlalchemy.sql.expression import Select as _Select
 
 _TSelect = TypeVar("_TSelect")
 
+
 class Select(_Select[_TSelect], Generic[_TSelect]):
     inherit_cache = True
 

--- a/sqlmodel/sql/expression.py
+++ b/sqlmodel/sql/expression.py
@@ -117,12 +117,12 @@ _TModel_3 = TypeVar("_TModel_3", bound="SQLModel")
 
 
 @overload
-def select(entity_0: _TScalar_0, **kw: Any) -> SelectOfScalar[_TScalar_0]:  # type: ignore
+def select(entity_0: _TScalar_0) -> SelectOfScalar[_TScalar_0]:  # type: ignore
     ...
 
 
 @overload
-def select(entity_0: Type[_TModel_0], **kw: Any) -> SelectOfScalar[_TModel_0]:  # type: ignore
+def select(entity_0: Type[_TModel_0]) -> SelectOfScalar[_TModel_0]:  # type: ignore
     ...
 
 
@@ -133,7 +133,6 @@ def select(entity_0: Type[_TModel_0], **kw: Any) -> SelectOfScalar[_TModel_0]:  
 def select(  # type: ignore
     entity_0: _TScalar_0,
     entity_1: _TScalar_1,
-    **kw: Any,
 ) -> Select[Tuple[_TScalar_0, _TScalar_1]]:
     ...
 
@@ -142,7 +141,6 @@ def select(  # type: ignore
 def select(  # type: ignore
     entity_0: _TScalar_0,
     entity_1: Type[_TModel_1],
-    **kw: Any,
 ) -> Select[Tuple[_TScalar_0, _TModel_1]]:
     ...
 
@@ -151,7 +149,6 @@ def select(  # type: ignore
 def select(  # type: ignore
     entity_0: Type[_TModel_0],
     entity_1: _TScalar_1,
-    **kw: Any,
 ) -> Select[Tuple[_TModel_0, _TScalar_1]]:
     ...
 
@@ -160,7 +157,6 @@ def select(  # type: ignore
 def select(  # type: ignore
     entity_0: Type[_TModel_0],
     entity_1: Type[_TModel_1],
-    **kw: Any,
 ) -> Select[Tuple[_TModel_0, _TModel_1]]:
     ...
 
@@ -170,7 +166,6 @@ def select(  # type: ignore
     entity_0: _TScalar_0,
     entity_1: _TScalar_1,
     entity_2: _TScalar_2,
-    **kw: Any,
 ) -> Select[Tuple[_TScalar_0, _TScalar_1, _TScalar_2]]:
     ...
 
@@ -180,7 +175,6 @@ def select(  # type: ignore
     entity_0: _TScalar_0,
     entity_1: _TScalar_1,
     entity_2: Type[_TModel_2],
-    **kw: Any,
 ) -> Select[Tuple[_TScalar_0, _TScalar_1, _TModel_2]]:
     ...
 
@@ -190,7 +184,6 @@ def select(  # type: ignore
     entity_0: _TScalar_0,
     entity_1: Type[_TModel_1],
     entity_2: _TScalar_2,
-    **kw: Any,
 ) -> Select[Tuple[_TScalar_0, _TModel_1, _TScalar_2]]:
     ...
 
@@ -200,7 +193,6 @@ def select(  # type: ignore
     entity_0: _TScalar_0,
     entity_1: Type[_TModel_1],
     entity_2: Type[_TModel_2],
-    **kw: Any,
 ) -> Select[Tuple[_TScalar_0, _TModel_1, _TModel_2]]:
     ...
 
@@ -210,7 +202,6 @@ def select(  # type: ignore
     entity_0: Type[_TModel_0],
     entity_1: _TScalar_1,
     entity_2: _TScalar_2,
-    **kw: Any,
 ) -> Select[Tuple[_TModel_0, _TScalar_1, _TScalar_2]]:
     ...
 
@@ -220,7 +211,6 @@ def select(  # type: ignore
     entity_0: Type[_TModel_0],
     entity_1: _TScalar_1,
     entity_2: Type[_TModel_2],
-    **kw: Any,
 ) -> Select[Tuple[_TModel_0, _TScalar_1, _TModel_2]]:
     ...
 
@@ -230,7 +220,6 @@ def select(  # type: ignore
     entity_0: Type[_TModel_0],
     entity_1: Type[_TModel_1],
     entity_2: _TScalar_2,
-    **kw: Any,
 ) -> Select[Tuple[_TModel_0, _TModel_1, _TScalar_2]]:
     ...
 
@@ -240,7 +229,6 @@ def select(  # type: ignore
     entity_0: Type[_TModel_0],
     entity_1: Type[_TModel_1],
     entity_2: Type[_TModel_2],
-    **kw: Any,
 ) -> Select[Tuple[_TModel_0, _TModel_1, _TModel_2]]:
     ...
 
@@ -251,7 +239,6 @@ def select(  # type: ignore
     entity_1: _TScalar_1,
     entity_2: _TScalar_2,
     entity_3: _TScalar_3,
-    **kw: Any,
 ) -> Select[Tuple[_TScalar_0, _TScalar_1, _TScalar_2, _TScalar_3]]:
     ...
 
@@ -262,7 +249,6 @@ def select(  # type: ignore
     entity_1: _TScalar_1,
     entity_2: _TScalar_2,
     entity_3: Type[_TModel_3],
-    **kw: Any,
 ) -> Select[Tuple[_TScalar_0, _TScalar_1, _TScalar_2, _TModel_3]]:
     ...
 
@@ -273,7 +259,6 @@ def select(  # type: ignore
     entity_1: _TScalar_1,
     entity_2: Type[_TModel_2],
     entity_3: _TScalar_3,
-    **kw: Any,
 ) -> Select[Tuple[_TScalar_0, _TScalar_1, _TModel_2, _TScalar_3]]:
     ...
 
@@ -284,7 +269,6 @@ def select(  # type: ignore
     entity_1: _TScalar_1,
     entity_2: Type[_TModel_2],
     entity_3: Type[_TModel_3],
-    **kw: Any,
 ) -> Select[Tuple[_TScalar_0, _TScalar_1, _TModel_2, _TModel_3]]:
     ...
 
@@ -295,7 +279,6 @@ def select(  # type: ignore
     entity_1: Type[_TModel_1],
     entity_2: _TScalar_2,
     entity_3: _TScalar_3,
-    **kw: Any,
 ) -> Select[Tuple[_TScalar_0, _TModel_1, _TScalar_2, _TScalar_3]]:
     ...
 
@@ -306,7 +289,6 @@ def select(  # type: ignore
     entity_1: Type[_TModel_1],
     entity_2: _TScalar_2,
     entity_3: Type[_TModel_3],
-    **kw: Any,
 ) -> Select[Tuple[_TScalar_0, _TModel_1, _TScalar_2, _TModel_3]]:
     ...
 
@@ -317,7 +299,6 @@ def select(  # type: ignore
     entity_1: Type[_TModel_1],
     entity_2: Type[_TModel_2],
     entity_3: _TScalar_3,
-    **kw: Any,
 ) -> Select[Tuple[_TScalar_0, _TModel_1, _TModel_2, _TScalar_3]]:
     ...
 
@@ -328,7 +309,6 @@ def select(  # type: ignore
     entity_1: Type[_TModel_1],
     entity_2: Type[_TModel_2],
     entity_3: Type[_TModel_3],
-    **kw: Any,
 ) -> Select[Tuple[_TScalar_0, _TModel_1, _TModel_2, _TModel_3]]:
     ...
 
@@ -339,7 +319,6 @@ def select(  # type: ignore
     entity_1: _TScalar_1,
     entity_2: _TScalar_2,
     entity_3: _TScalar_3,
-    **kw: Any,
 ) -> Select[Tuple[_TModel_0, _TScalar_1, _TScalar_2, _TScalar_3]]:
     ...
 
@@ -350,7 +329,6 @@ def select(  # type: ignore
     entity_1: _TScalar_1,
     entity_2: _TScalar_2,
     entity_3: Type[_TModel_3],
-    **kw: Any,
 ) -> Select[Tuple[_TModel_0, _TScalar_1, _TScalar_2, _TModel_3]]:
     ...
 
@@ -361,7 +339,6 @@ def select(  # type: ignore
     entity_1: _TScalar_1,
     entity_2: Type[_TModel_2],
     entity_3: _TScalar_3,
-    **kw: Any,
 ) -> Select[Tuple[_TModel_0, _TScalar_1, _TModel_2, _TScalar_3]]:
     ...
 
@@ -372,7 +349,6 @@ def select(  # type: ignore
     entity_1: _TScalar_1,
     entity_2: Type[_TModel_2],
     entity_3: Type[_TModel_3],
-    **kw: Any,
 ) -> Select[Tuple[_TModel_0, _TScalar_1, _TModel_2, _TModel_3]]:
     ...
 
@@ -383,7 +359,6 @@ def select(  # type: ignore
     entity_1: Type[_TModel_1],
     entity_2: _TScalar_2,
     entity_3: _TScalar_3,
-    **kw: Any,
 ) -> Select[Tuple[_TModel_0, _TModel_1, _TScalar_2, _TScalar_3]]:
     ...
 
@@ -394,7 +369,6 @@ def select(  # type: ignore
     entity_1: Type[_TModel_1],
     entity_2: _TScalar_2,
     entity_3: Type[_TModel_3],
-    **kw: Any,
 ) -> Select[Tuple[_TModel_0, _TModel_1, _TScalar_2, _TModel_3]]:
     ...
 
@@ -405,7 +379,6 @@ def select(  # type: ignore
     entity_1: Type[_TModel_1],
     entity_2: Type[_TModel_2],
     entity_3: _TScalar_3,
-    **kw: Any,
 ) -> Select[Tuple[_TModel_0, _TModel_1, _TModel_2, _TScalar_3]]:
     ...
 
@@ -416,7 +389,6 @@ def select(  # type: ignore
     entity_1: Type[_TModel_1],
     entity_2: Type[_TModel_2],
     entity_3: Type[_TModel_3],
-    **kw: Any,
 ) -> Select[Tuple[_TModel_0, _TModel_1, _TModel_2, _TModel_3]]:
     ...
 
@@ -424,10 +396,10 @@ def select(  # type: ignore
 # Generated overloads end
 
 
-def select(*entities: Any, **kw: Any) -> Union[Select, SelectOfScalar]:  # type: ignore
+def select(*entities: Any) -> Union[Select, SelectOfScalar]:  # type: ignore
     if len(entities) == 1:
-        return SelectOfScalar._create(*entities, **kw)  # type: ignore
-    return Select._create(*entities, **kw)  # type: ignore
+        return SelectOfScalar(*entities)  # type: ignore
+    return Select(*entities)  # type: ignore
 
 
 # TODO: add several @overload from Python types to SQLAlchemy equivalents

--- a/sqlmodel/sql/expression.py.jinja2
+++ b/sqlmodel/sql/expression.py.jinja2
@@ -30,12 +30,6 @@ class Select(_Select[Tuple[_TSelect]], Generic[_TSelect]):
 class SelectOfScalar(_Select[Tuple[_TSelect]], Generic[_TSelect]):
     inherit_cache = True
 
-# This is not comparable to sqlalchemy.sql.selectable.ScalarSelect, that has a different
-# purpose. This is the same as a normal SQLAlchemy Select class where there's only one
-# entity, so the result will be converted to a scalar by default. This way writing
-# for loops on the results will feel natural.
-class SelectOfScalar(_Select, Generic[_TSelect]):
-    inherit_cache = True
 
 if TYPE_CHECKING:  # pragma: no cover
     from ..main import SQLModel

--- a/sqlmodel/sql/expression.py.jinja2
+++ b/sqlmodel/sql/expression.py.jinja2
@@ -20,14 +20,14 @@ from sqlalchemy.sql.expression import Select as _Select
 
 _TSelect = TypeVar("_TSelect")
 
-class Select(_Select[_TSelect], Generic[_TSelect]):
+class Select(_Select[Tuple[_TSelect]], Generic[_TSelect]):
     inherit_cache = True
 
 # This is not comparable to sqlalchemy.sql.selectable.ScalarSelect, that has a different
 # purpose. This is the same as a normal SQLAlchemy Select class where there's only one
 # entity, so the result will be converted to a scalar by default. This way writing
 # for loops on the results will feel natural.
-class SelectOfScalar(_Select[_TSelect], Generic[_TSelect]):
+class SelectOfScalar(_Select[Tuple[_TSelect]], Generic[_TSelect]):
     inherit_cache = True
 
 # This is not comparable to sqlalchemy.sql.selectable.ScalarSelect, that has a different

--- a/sqlmodel/sql/expression.py.jinja2
+++ b/sqlmodel/sql/expression.py.jinja2
@@ -20,7 +20,14 @@ from sqlalchemy.sql.expression import Select as _Select
 
 _TSelect = TypeVar("_TSelect")
 
-class Select(_Select, Generic[_TSelect]):
+class Select(_Select[_TSelect], Generic[_TSelect]):
+    inherit_cache = True
+
+# This is not comparable to sqlalchemy.sql.selectable.ScalarSelect, that has a different
+# purpose. This is the same as a normal SQLAlchemy Select class where there's only one
+# entity, so the result will be converted to a scalar by default. This way writing
+# for loops on the results will feel natural.
+class SelectOfScalar(_Select[_TSelect], Generic[_TSelect]):
     inherit_cache = True
 
 # This is not comparable to sqlalchemy.sql.selectable.ScalarSelect, that has a different
@@ -34,6 +41,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from ..main import SQLModel
 
 # Generated TypeVars start
+
 
 {% for i in range(number_of_types) %}
 _TScalar_{{ i }} = TypeVar(
@@ -58,12 +66,12 @@ _TModel_{{ i }} = TypeVar("_TModel_{{ i }}", bound="SQLModel")
 # Generated TypeVars end
 
 @overload
-def select(entity_0: _TScalar_0, **kw: Any) -> SelectOfScalar[_TScalar_0]:  # type: ignore
+def select(entity_0: _TScalar_0) -> SelectOfScalar[_TScalar_0]:  # type: ignore
     ...
 
 
 @overload
-def select(entity_0: Type[_TModel_0], **kw: Any) -> SelectOfScalar[_TModel_0]:  # type: ignore
+def select(entity_0: Type[_TModel_0]) -> SelectOfScalar[_TModel_0]:  # type: ignore
     ...
 
 
@@ -73,7 +81,7 @@ def select(entity_0: Type[_TModel_0], **kw: Any) -> SelectOfScalar[_TModel_0]:  
 
 @overload
 def select(  # type: ignore
-    {% for arg in signature[0] %}{{ arg.name }}: {{ arg.annotation }}, {% endfor %}**kw: Any,
+    {% for arg in signature[0] %}{{ arg.name }}: {{ arg.annotation }}, {% endfor %}
     ) -> Select[Tuple[{%for ret in signature[1] %}{{ ret }} {% if not loop.last %}, {% endif %}{% endfor %}]]:
     ...
 
@@ -81,14 +89,15 @@ def select(  # type: ignore
 
 # Generated overloads end
 
-def select(*entities: Any, **kw: Any) -> Union[Select, SelectOfScalar]:  # type: ignore
+
+def select(*entities: Any) -> Union[Select, SelectOfScalar]:  # type: ignore
     if len(entities) == 1:
-        return SelectOfScalar._create(*entities, **kw)  # type: ignore
-    return Select._create(*entities, **kw)  # type: ignore
+        return SelectOfScalar(*entities)  # type: ignore
+    return Select(*entities)  # type: ignore
 
 
 # TODO: add several @overload from Python types to SQLAlchemy equivalents
 def col(column_expression: Any) -> ColumnClause:  # type: ignore
     if not isinstance(column_expression, (ColumnClause, Column, InstrumentedAttribute)):
         raise RuntimeError(f"Not a SQLAlchemy column: {column_expression}")
-    return column_expression
+    return column_expression  # type: ignore

--- a/sqlmodel/sql/sqltypes.py
+++ b/sqlmodel/sql/sqltypes.py
@@ -8,7 +8,6 @@ from sqlalchemy.sql.type_api import TypeEngine
 
 
 class AutoString(types.TypeDecorator):  # type: ignore
-
     impl = types.String
     cache_ok = True
     mysql_default_length = 255

--- a/sqlmodel/sql/sqltypes.py
+++ b/sqlmodel/sql/sqltypes.py
@@ -16,7 +16,7 @@ class AutoString(types.TypeDecorator):  # type: ignore
     def load_dialect_impl(self, dialect: Dialect) -> "types.TypeEngine[Any]":
         impl = cast(types.String, self.impl)
         if impl.length is None and dialect.name == "mysql":
-            return dialect.type_descriptor(types.String(self.mysql_default_length))  # type: ignore
+            return dialect.type_descriptor(types.String(self.mysql_default_length))
         return super().load_dialect_impl(dialect)
 
 
@@ -35,9 +35,9 @@ class GUID(types.TypeDecorator):  # type: ignore
 
     def load_dialect_impl(self, dialect: Dialect) -> TypeEngine:  # type: ignore
         if dialect.name == "postgresql":
-            return dialect.type_descriptor(UUID())  # type: ignore
+            return dialect.type_descriptor(UUID())
         else:
-            return dialect.type_descriptor(CHAR(32))  # type: ignore
+            return dialect.type_descriptor(CHAR(32))
 
     def process_bind_param(self, value: Any, dialect: Dialect) -> Optional[str]:
         if value is None:

--- a/sqlmodel/typing.py
+++ b/sqlmodel/typing.py
@@ -1,0 +1,7 @@
+from pydantic import ConfigDict
+from typing import Optional, Any
+
+class SQLModelConfig(ConfigDict):
+    table: Optional[bool]
+    read_from_attributes: Optional[bool]
+    registry: Optional[Any]

--- a/sqlmodel/typing.py
+++ b/sqlmodel/typing.py
@@ -1,5 +1,7 @@
+from typing import Any, Optional
+
 from pydantic import ConfigDict
-from typing import Optional, Any
+
 
 class SQLModelConfig(ConfigDict):
     table: Optional[bool]

--- a/sqlmodel/typing.py
+++ b/sqlmodel/typing.py
@@ -3,7 +3,7 @@ from typing import Any, Optional
 from pydantic import ConfigDict
 
 
-class SQLModelConfig(ConfigDict):
+class SQLModelConfig(ConfigDict, total=False):
     table: Optional[bool]
     read_from_attributes: Optional[bool]
     registry: Optional[Any]

--- a/tests/test_class_hierarchy.py
+++ b/tests/test_class_hierarchy.py
@@ -1,0 +1,79 @@
+import datetime
+import sys
+
+import pytest
+from pydantic import AnyUrl, UrlConstraints
+from typing_extensions import Annotated
+
+from sqlmodel import (
+    BigInteger,
+    Column,
+    DateTime,
+    Field,
+    Integer,
+    SQLModel,
+    String,
+    create_engine,
+)
+
+MoveSharedUrl = Annotated[
+    AnyUrl, UrlConstraints(max_length=512, allowed_schemes=["smb", "ftp", "file"])
+]
+
+
+@pytest.mark.skipif(sys.version_info < (3, 10))
+def test_field_resuse():
+    class BasicFileLog(SQLModel):
+        resourceID: int = Field(
+            sa_column=lambda: Column(Integer, index=True), description="""   """
+        )
+        transportID: Annotated[int | None, Field(description=" for ")] = None
+        fileName: str = Field(
+            sa_column=lambda: Column(String, index=True), description=""" """
+        )
+        fileSize: int | None = Field(
+            sa_column=lambda: Column(BigInteger), ge=0, description=""" """
+        )
+        beginTime: datetime.datetime | None = Field(
+            sa_column=lambda: Column(
+                DateTime(timezone=True),
+                index=True,
+            ),
+            description="",
+        )
+
+    class SendFileLog(BasicFileLog, table=True):
+        id: int | None = Field(
+            sa_column=Column(Integer, primary_key=True, autoincrement=True),
+            description="""   """,
+        )
+        sendUser: str
+        dstUrl: MoveSharedUrl | None
+
+    class RecvFileLog(BasicFileLog, table=True):
+        id: int | None = Field(
+            sa_column=Column(Integer, primary_key=True, autoincrement=True),
+            description="""   """,
+        )
+        recvUser: str
+
+    sqlite_file_name = "database.db"
+    sqlite_url = f"sqlite:///{sqlite_file_name}"
+
+    engine = create_engine(sqlite_url, echo=True)
+    SQLModel.metadata.drop_all(engine)
+    SQLModel.metadata.create_all(engine)
+    SendFileLog(
+        sendUser="j",
+        resourceID=1,
+        fileName="a.txt",
+        fileSize=3234,
+        beginTime=datetime.datetime.now(),
+    )
+    RecvFileLog(
+        sendUser="j",
+        resourceID=1,
+        fileName="a.txt",
+        fileSize=3234,
+        beginTime=datetime.datetime.now(),
+    )

--- a/tests/test_class_hierarchy.py
+++ b/tests/test_class_hierarchy.py
@@ -3,8 +3,6 @@ import sys
 
 import pytest
 from pydantic import AnyUrl, UrlConstraints
-from typing_extensions import Annotated
-
 from sqlmodel import (
     BigInteger,
     Column,
@@ -15,6 +13,7 @@ from sqlmodel import (
     String,
     create_engine,
 )
+from typing_extensions import Annotated
 
 MoveSharedUrl = Annotated[
     AnyUrl, UrlConstraints(max_length=512, allowed_schemes=["smb", "ftp", "file"])

--- a/tests/test_class_hierarchy.py
+++ b/tests/test_class_hierarchy.py
@@ -20,7 +20,7 @@ MoveSharedUrl = Annotated[
 ]
 
 
-@pytest.mark.skipif(sys.version_info < (3, 10))
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="requires python3.10 or higher")
 def test_field_resuse():
     class BasicFileLog(SQLModel):
         resourceID: int = Field(

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from sqlmodel.default import Default
 
 
@@ -9,7 +11,7 @@ def test_default_bool() -> None:
     df1 = Default(False)
     df2 = Default(0)
     df3 = Default("")
-    df4: list = Default([])
+    df4: list[Any] = Default([])
     df5 = Default(None)
 
     assert not not dt1

--- a/tests/test_instance_no_args.py
+++ b/tests/test_instance_no_args.py
@@ -8,7 +8,7 @@ from sqlmodel import Field, SQLModel
 def test_allow_instantiation_without_arguments(clear_sqlmodel):
     class Item(SQLModel):
         id: Optional[int] = Field(default=None, primary_key=True)
-        name: str
+        name: str 
         description: Optional[str] = None
 
         class Config:

--- a/tests/test_instance_no_args.py
+++ b/tests/test_instance_no_args.py
@@ -8,7 +8,7 @@ from sqlmodel import Field, SQLModel
 def test_allow_instantiation_without_arguments(clear_sqlmodel):
     class Item(SQLModel):
         id: Optional[int] = Field(default=None, primary_key=True)
-        name: str 
+        name: str
         description: Optional[str] = None
 
         class Config:

--- a/tests/test_missing_type.py
+++ b/tests/test_missing_type.py
@@ -1,8 +1,8 @@
 from typing import Optional
 
 import pytest
-from sqlmodel import Field, SQLModel
 from pydantic import BaseModel
+from sqlmodel import Field, SQLModel
 
 
 def test_missing_sql_type():

--- a/tests/test_missing_type.py
+++ b/tests/test_missing_type.py
@@ -2,10 +2,11 @@ from typing import Optional
 
 import pytest
 from sqlmodel import Field, SQLModel
+from pydantic import BaseModel
 
 
 def test_missing_sql_type():
-    class CustomType:
+    class CustomType(BaseModel):
         @classmethod
         def __get_validators__(cls):
             yield cls.validate

--- a/tests/test_model_copy.py
+++ b/tests/test_model_copy.py
@@ -1,0 +1,49 @@
+from typing import Optional
+
+import pytest
+from pydantic import field_validator
+from pydantic.error_wrappers import ValidationError
+from sqlmodel import SQLModel, create_engine, Session, Field
+
+
+def test_model_copy(clear_sqlmodel):
+    """Test validation of implicit and explict None values.
+
+    # For consistency with pydantic, validators are not to be called on
+    # arguments that are not explicitly provided.
+
+    https://github.com/tiangolo/sqlmodel/issues/230
+    https://github.com/samuelcolvin/pydantic/issues/1223
+
+    """
+
+    class Hero(SQLModel, table=True):
+        id: Optional[int] = Field(default=None, primary_key=True)
+        name: str
+        secret_name: str
+        age: Optional[int] = None
+
+    hero = Hero(name="Deadpond", secret_name="Dive Wilson", age=25)
+
+    engine = create_engine("sqlite://")
+
+    SQLModel.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        session.add(hero)
+        session.commit()
+        session.refresh(hero)
+
+    model_copy = hero.model_copy(update={"name": "Deadpond Copy"})
+
+    assert model_copy.name == "Deadpond Copy" and \
+           model_copy.secret_name == "Dive Wilson" and \
+           model_copy.age == 25
+
+    db_hero = session.get(Hero, hero.id)
+
+    db_copy = db_hero.model_copy(update={"name": "Deadpond Copy"})
+
+    assert db_copy.name == "Deadpond Copy" and \
+           db_copy.secret_name == "Dive Wilson" and \
+           db_copy.age == 25

--- a/tests/test_model_copy.py
+++ b/tests/test_model_copy.py
@@ -1,8 +1,5 @@
 from typing import Optional
 
-import pytest
-from pydantic import field_validator
-from pydantic.error_wrappers import ValidationError
 from sqlmodel import Field, Session, SQLModel, create_engine
 
 

--- a/tests/test_model_copy.py
+++ b/tests/test_model_copy.py
@@ -3,7 +3,7 @@ from typing import Optional
 import pytest
 from pydantic import field_validator
 from pydantic.error_wrappers import ValidationError
-from sqlmodel import SQLModel, create_engine, Session, Field
+from sqlmodel import Field, Session, SQLModel, create_engine
 
 
 def test_model_copy(clear_sqlmodel):
@@ -36,14 +36,18 @@ def test_model_copy(clear_sqlmodel):
 
     model_copy = hero.model_copy(update={"name": "Deadpond Copy"})
 
-    assert model_copy.name == "Deadpond Copy" and \
-           model_copy.secret_name == "Dive Wilson" and \
-           model_copy.age == 25
+    assert (
+        model_copy.name == "Deadpond Copy"
+        and model_copy.secret_name == "Dive Wilson"
+        and model_copy.age == 25
+    )
 
     db_hero = session.get(Hero, hero.id)
 
     db_copy = db_hero.model_copy(update={"name": "Deadpond Copy"})
 
-    assert db_copy.name == "Deadpond Copy" and \
-           db_copy.secret_name == "Dive Wilson" and \
-           db_copy.age == 25
+    assert (
+        db_copy.name == "Deadpond Copy"
+        and db_copy.secret_name == "Dive Wilson"
+        and db_copy.age == 25
+    )

--- a/tests/test_nullable.py
+++ b/tests/test_nullable.py
@@ -3,6 +3,9 @@ from typing import Optional
 import pytest
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import Field, Session, SQLModel, create_engine
+from typing_extensions import Annotated
+from pydantic import AnyUrl, UrlConstraints
+MoveSharedUrl =  Annotated[AnyUrl, UrlConstraints(max_length=512, allowed_schemes=['smb', 'ftp','file'])]
 
 
 def test_nullable_fields(clear_sqlmodel, caplog):
@@ -49,6 +52,7 @@ def test_nullable_fields(clear_sqlmodel, caplog):
         str_default_str_nullable: str = Field(default="default", nullable=True)
         str_default_ellipsis_non_nullable: str = Field(default=..., nullable=False)
         str_default_ellipsis_nullable: str = Field(default=..., nullable=True)
+        annotated_any_url: MoveSharedUrl | None = Field(description="")
 
     engine = create_engine("sqlite://", echo=True)
     SQLModel.metadata.create_all(engine)
@@ -77,6 +81,7 @@ def test_nullable_fields(clear_sqlmodel, caplog):
     assert "str_default_str_nullable VARCHAR," in create_table_log
     assert "str_default_ellipsis_non_nullable VARCHAR NOT NULL," in create_table_log
     assert "str_default_ellipsis_nullable VARCHAR," in create_table_log
+    assert "annotated_any_url  VARCHAR(512)," in create_table_log
 
 
 # Test for regression in https://github.com/tiangolo/sqlmodel/issues/420

--- a/tests/test_nullable.py
+++ b/tests/test_nullable.py
@@ -1,11 +1,14 @@
 from typing import Optional
 
 import pytest
+from pydantic import AnyUrl, UrlConstraints
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import Field, Session, SQLModel, create_engine
 from typing_extensions import Annotated
-from pydantic import AnyUrl, UrlConstraints
-MoveSharedUrl =  Annotated[AnyUrl, UrlConstraints(max_length=512, allowed_schemes=['smb', 'ftp','file'])]
+
+MoveSharedUrl = Annotated[
+    AnyUrl, UrlConstraints(max_length=512, allowed_schemes=["smb", "ftp", "file"])
+]
 
 
 def test_nullable_fields(clear_sqlmodel, caplog):

--- a/tests/test_nullable.py
+++ b/tests/test_nullable.py
@@ -57,7 +57,7 @@ def test_nullable_fields(clear_sqlmodel, caplog):
         str_default_str_nullable: str = Field(default="default", nullable=True)
         str_default_ellipsis_non_nullable: str = Field(default=..., nullable=False)
         str_default_ellipsis_nullable: str = Field(default=..., nullable=True)
-        base_url : AnyUrl
+        base_url: AnyUrl
         optional_url: Optional[MoveSharedUrl] = Field(default=None, description="")
         url: MoveSharedUrl
         annotated_url: Annotated[MoveSharedUrl, Field(description="")]

--- a/tests/test_nullable.py
+++ b/tests/test_nullable.py
@@ -19,6 +19,8 @@ def test_nullable_fields(clear_sqlmodel, caplog):
         )
         required_value: str
         optional_default_ellipsis: Optional[str] = Field(default=...)
+        optional_no_field: Optional[str]
+        optional_no_field_default: Optional[str] = Field(description="no default")
         optional_default_none: Optional[str] = Field(default=None)
         optional_non_nullable: Optional[str] = Field(
             nullable=False,
@@ -55,7 +57,7 @@ def test_nullable_fields(clear_sqlmodel, caplog):
         str_default_str_nullable: str = Field(default="default", nullable=True)
         str_default_ellipsis_non_nullable: str = Field(default=..., nullable=False)
         str_default_ellipsis_nullable: str = Field(default=..., nullable=True)
-        annotated_any_url: MoveSharedUrl | None = Field(description="")
+        annotated_any_url: Optional[MoveSharedUrl] = Field(description="")
 
     engine = create_engine("sqlite://", echo=True)
     SQLModel.metadata.create_all(engine)
@@ -66,6 +68,8 @@ def test_nullable_fields(clear_sqlmodel, caplog):
     assert "primary_key INTEGER NOT NULL," in create_table_log
     assert "required_value VARCHAR NOT NULL," in create_table_log
     assert "optional_default_ellipsis VARCHAR NOT NULL," in create_table_log
+    assert "optional_no_field VARCHAR," in create_table_log
+    assert "optional_no_field_default VARCHAR NOT NULL," in create_table_log
     assert "optional_default_none VARCHAR," in create_table_log
     assert "optional_non_nullable VARCHAR NOT NULL," in create_table_log
     assert "optional_nullable VARCHAR," in create_table_log

--- a/tests/test_nullable.py
+++ b/tests/test_nullable.py
@@ -57,7 +57,12 @@ def test_nullable_fields(clear_sqlmodel, caplog):
         str_default_str_nullable: str = Field(default="default", nullable=True)
         str_default_ellipsis_non_nullable: str = Field(default=..., nullable=False)
         str_default_ellipsis_nullable: str = Field(default=..., nullable=True)
-        annotated_any_url: Optional[MoveSharedUrl] = Field(description="")
+        optional_url: Optional[MoveSharedUrl] = Field(default=None, description="")
+        url: MoveSharedUrl
+        annotated_url: Annotated[MoveSharedUrl, Field(description="")]
+        annotated_optional_url: Annotated[
+            Optional[MoveSharedUrl], Field(description="")
+        ] = None
 
     engine = create_engine("sqlite://", echo=True)
     SQLModel.metadata.create_all(engine)
@@ -88,7 +93,10 @@ def test_nullable_fields(clear_sqlmodel, caplog):
     assert "str_default_str_nullable VARCHAR," in create_table_log
     assert "str_default_ellipsis_non_nullable VARCHAR NOT NULL," in create_table_log
     assert "str_default_ellipsis_nullable VARCHAR," in create_table_log
-    assert "annotated_any_url VARCHAR(512) NOT NULL" in create_table_log
+    assert "optional_url VARCHAR(512), " in create_table_log
+    assert "url VARCHAR(512) NOT NULL," in create_table_log
+    assert "annotated_url VARCHAR(512) NOT NULL," in create_table_log
+    assert "annotated_optional_url VARCHAR(512)," in create_table_log
 
 
 # Test for regression in https://github.com/tiangolo/sqlmodel/issues/420

--- a/tests/test_nullable.py
+++ b/tests/test_nullable.py
@@ -57,6 +57,7 @@ def test_nullable_fields(clear_sqlmodel, caplog):
         str_default_str_nullable: str = Field(default="default", nullable=True)
         str_default_ellipsis_non_nullable: str = Field(default=..., nullable=False)
         str_default_ellipsis_nullable: str = Field(default=..., nullable=True)
+        base_url : AnyUrl
         optional_url: Optional[MoveSharedUrl] = Field(default=None, description="")
         url: MoveSharedUrl
         annotated_url: Annotated[MoveSharedUrl, Field(description="")]
@@ -93,6 +94,7 @@ def test_nullable_fields(clear_sqlmodel, caplog):
     assert "str_default_str_nullable VARCHAR," in create_table_log
     assert "str_default_ellipsis_non_nullable VARCHAR NOT NULL," in create_table_log
     assert "str_default_ellipsis_nullable VARCHAR," in create_table_log
+    assert "base_url VARCHAR NOT NULL," in create_table_log
     assert "optional_url VARCHAR(512), " in create_table_log
     assert "url VARCHAR(512) NOT NULL," in create_table_log
     assert "annotated_url VARCHAR(512) NOT NULL," in create_table_log

--- a/tests/test_nullable.py
+++ b/tests/test_nullable.py
@@ -88,7 +88,7 @@ def test_nullable_fields(clear_sqlmodel, caplog):
     assert "str_default_str_nullable VARCHAR," in create_table_log
     assert "str_default_ellipsis_non_nullable VARCHAR NOT NULL," in create_table_log
     assert "str_default_ellipsis_nullable VARCHAR," in create_table_log
-    assert "annotated_any_url  VARCHAR(512)," in create_table_log
+    assert "annotated_any_url VARCHAR(512) NOT NULL" in create_table_log
 
 
 # Test for regression in https://github.com/tiangolo/sqlmodel/issues/420

--- a/tests/test_pydantic_types.py
+++ b/tests/test_pydantic_types.py
@@ -1,0 +1,24 @@
+from pydantic import EmailStr, HttpUrl, ImportString, NameEmail
+from sqlmodel import Field, SQLModel, create_engine
+
+
+def test_pydantic_types(clear_sqlmodel, caplog):
+    class Hero(SQLModel, table=True):
+        integer_primary_key: int = Field(
+            primary_key=True,
+        )
+        http: HttpUrl = Field(max_length=250)
+        email: EmailStr
+        name_email: NameEmail = Field(max_length=50)
+        import_string: ImportString = Field(max_length=200, min_length=100)
+
+    engine = create_engine("sqlite://", echo=True)
+    SQLModel.metadata.create_all(engine)
+
+    create_table_log = [
+        message for message in caplog.messages if "CREATE TABLE hero" in message
+    ][0]
+    assert "http VARCHAR(250) NOT NULL," in create_table_log
+    assert "email VARCHAR NOT NULL," in create_table_log
+    assert "name_email VARCHAR(50) NOT NULL," in create_table_log
+    assert "import_string VARCHAR(200) NOT NULL," in create_table_log

--- a/tests/test_tutorial/test_fastapi/test_delete/test_tutorial001.py
+++ b/tests/test_tutorial/test_fastapi/test_delete/test_tutorial001.py
@@ -3,7 +3,7 @@ from sqlmodel import create_engine
 from sqlmodel.pool import StaticPool
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/heroes/": {
@@ -210,7 +210,10 @@ openapi_schema = {
                 "properties": {
                     "name": {"title": "Name", "type": "string"},
                     "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                 },
             },
             "HeroRead": {
@@ -220,7 +223,10 @@ openapi_schema = {
                 "properties": {
                     "name": {"title": "Name", "type": "string"},
                     "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                     "id": {"title": "Id", "type": "integer"},
                 },
             },
@@ -228,9 +234,18 @@ openapi_schema = {
                 "title": "HeroUpdate",
                 "type": "object",
                 "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
+                    "name": {
+                        "title": "Name",
+                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                    },
+                    "secret_name": {
+                        "title": "Secret Name",
+                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                    },
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                 },
             },
             "ValidationError": {
@@ -241,7 +256,7 @@ openapi_schema = {
                     "loc": {
                         "title": "Location",
                         "type": "array",
-                        "items": {"type": "string"},
+                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
                     },
                     "msg": {"title": "Message", "type": "string"},
                     "type": {"title": "Error Type", "type": "string"},
@@ -261,7 +276,6 @@ def test_tutorial(clear_sqlmodel):
     )
 
     with TestClient(mod.app) as client:
-
         hero1_data = {"name": "Deadpond", "secret_name": "Dive Wilson"}
         hero2_data = {
             "name": "Spider-Boy",

--- a/tests/test_tutorial/test_fastapi/test_limit_and_offset/test_tutorial001.py
+++ b/tests/test_tutorial/test_fastapi/test_limit_and_offset/test_tutorial001.py
@@ -3,7 +3,7 @@ from sqlmodel import create_engine
 from sqlmodel.pool import StaticPool
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/heroes/": {
@@ -142,7 +142,10 @@ openapi_schema = {
                 "properties": {
                     "name": {"title": "Name", "type": "string"},
                     "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                 },
             },
             "HeroRead": {
@@ -152,7 +155,10 @@ openapi_schema = {
                 "properties": {
                     "name": {"title": "Name", "type": "string"},
                     "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                     "id": {"title": "Id", "type": "integer"},
                 },
             },
@@ -164,7 +170,7 @@ openapi_schema = {
                     "loc": {
                         "title": "Location",
                         "type": "array",
-                        "items": {"type": "string"},
+                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
                     },
                     "msg": {"title": "Message", "type": "string"},
                     "type": {"title": "Error Type", "type": "string"},
@@ -184,7 +190,6 @@ def test_tutorial(clear_sqlmodel):
     )
 
     with TestClient(mod.app) as client:
-
         hero1_data = {"name": "Deadpond", "secret_name": "Dive Wilson"}
         hero2_data = {
             "name": "Spider-Boy",

--- a/tests/test_tutorial/test_fastapi/test_multiple_models/test_tutorial001.py
+++ b/tests/test_tutorial/test_fastapi/test_multiple_models/test_tutorial001.py
@@ -173,8 +173,8 @@ def test_tutorial(clear_sqlmodel):
     insp: Inspector = inspect(mod.engine)
     indexes = insp.get_indexes(str(mod.Hero.__tablename__))
     expected_indexes = [
-        {"name": "ix_hero_name", "column_names": ["name"], "unique": 0},
-        {"name": "ix_hero_age", "column_names": ["age"], "unique": 0},
+        {"name": "ix_hero_name", "column_names": ["name"], "unique": 0, 'dialect_options': {}},
+        {"name": "ix_hero_age", "column_names": ["age"], "unique": 0, 'dialect_options': {}},
     ]
     for index in expected_indexes:
         assert index in indexes, "This expected index should be in the indexes in DB"

--- a/tests/test_tutorial/test_fastapi/test_multiple_models/test_tutorial001.py
+++ b/tests/test_tutorial/test_fastapi/test_multiple_models/test_tutorial001.py
@@ -5,7 +5,7 @@ from sqlmodel import create_engine
 from sqlmodel.pool import StaticPool
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/heroes/": {
@@ -81,7 +81,10 @@ openapi_schema = {
                 "properties": {
                     "name": {"title": "Name", "type": "string"},
                     "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                 },
             },
             "HeroRead": {
@@ -92,7 +95,10 @@ openapi_schema = {
                     "id": {"title": "Id", "type": "integer"},
                     "name": {"title": "Name", "type": "string"},
                     "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                 },
             },
             "ValidationError": {
@@ -103,7 +109,7 @@ openapi_schema = {
                     "loc": {
                         "title": "Location",
                         "type": "array",
-                        "items": {"type": "string"},
+                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
                     },
                     "msg": {"title": "Message", "type": "string"},
                     "type": {"title": "Error Type", "type": "string"},
@@ -123,7 +129,6 @@ def test_tutorial(clear_sqlmodel):
     )
 
     with TestClient(mod.app) as client:
-
         hero1_data = {"name": "Deadpond", "secret_name": "Dive Wilson"}
         hero2_data = {
             "name": "Spider-Boy",

--- a/tests/test_tutorial/test_fastapi/test_multiple_models/test_tutorial001.py
+++ b/tests/test_tutorial/test_fastapi/test_multiple_models/test_tutorial001.py
@@ -173,8 +173,18 @@ def test_tutorial(clear_sqlmodel):
     insp: Inspector = inspect(mod.engine)
     indexes = insp.get_indexes(str(mod.Hero.__tablename__))
     expected_indexes = [
-        {"name": "ix_hero_name", "column_names": ["name"], "unique": 0, 'dialect_options': {}},
-        {"name": "ix_hero_age", "column_names": ["age"], "unique": 0, 'dialect_options': {}},
+        {
+            "name": "ix_hero_name",
+            "column_names": ["name"],
+            "unique": 0,
+            "dialect_options": {},
+        },
+        {
+            "name": "ix_hero_age",
+            "column_names": ["age"],
+            "unique": 0,
+            "dialect_options": {},
+        },
     ]
     for index in expected_indexes:
         assert index in indexes, "This expected index should be in the indexes in DB"

--- a/tests/test_tutorial/test_fastapi/test_multiple_models/test_tutorial002.py
+++ b/tests/test_tutorial/test_fastapi/test_multiple_models/test_tutorial002.py
@@ -173,8 +173,18 @@ def test_tutorial(clear_sqlmodel):
     insp: Inspector = inspect(mod.engine)
     indexes = insp.get_indexes(str(mod.Hero.__tablename__))
     expected_indexes = [
-        {"name": "ix_hero_age", "column_names": ["age"], "unique": 0, 'dialect_options': {}},
-        {"name": "ix_hero_name", "column_names": ["name"], "unique": 0, 'dialect_options': {}},
+        {
+            "name": "ix_hero_age",
+            "column_names": ["age"],
+            "unique": 0,
+            "dialect_options": {},
+        },
+        {
+            "name": "ix_hero_name",
+            "column_names": ["name"],
+            "unique": 0,
+            "dialect_options": {},
+        },
     ]
     for index in expected_indexes:
         assert index in indexes, "This expected index should be in the indexes in DB"

--- a/tests/test_tutorial/test_fastapi/test_multiple_models/test_tutorial002.py
+++ b/tests/test_tutorial/test_fastapi/test_multiple_models/test_tutorial002.py
@@ -5,7 +5,7 @@ from sqlmodel import create_engine
 from sqlmodel.pool import StaticPool
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/heroes/": {
@@ -81,7 +81,10 @@ openapi_schema = {
                 "properties": {
                     "name": {"title": "Name", "type": "string"},
                     "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                 },
             },
             "HeroRead": {
@@ -91,7 +94,10 @@ openapi_schema = {
                 "properties": {
                     "name": {"title": "Name", "type": "string"},
                     "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                     "id": {"title": "Id", "type": "integer"},
                 },
             },
@@ -103,7 +109,7 @@ openapi_schema = {
                     "loc": {
                         "title": "Location",
                         "type": "array",
-                        "items": {"type": "string"},
+                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
                     },
                     "msg": {"title": "Message", "type": "string"},
                     "type": {"title": "Error Type", "type": "string"},
@@ -123,7 +129,6 @@ def test_tutorial(clear_sqlmodel):
     )
 
     with TestClient(mod.app) as client:
-
         hero1_data = {"name": "Deadpond", "secret_name": "Dive Wilson"}
         hero2_data = {
             "name": "Spider-Boy",

--- a/tests/test_tutorial/test_fastapi/test_multiple_models/test_tutorial002.py
+++ b/tests/test_tutorial/test_fastapi/test_multiple_models/test_tutorial002.py
@@ -173,8 +173,8 @@ def test_tutorial(clear_sqlmodel):
     insp: Inspector = inspect(mod.engine)
     indexes = insp.get_indexes(str(mod.Hero.__tablename__))
     expected_indexes = [
-        {"name": "ix_hero_age", "column_names": ["age"], "unique": 0},
-        {"name": "ix_hero_name", "column_names": ["name"], "unique": 0},
+        {"name": "ix_hero_age", "column_names": ["age"], "unique": 0, 'dialect_options': {}},
+        {"name": "ix_hero_name", "column_names": ["name"], "unique": 0, 'dialect_options': {}},
     ]
     for index in expected_indexes:
         assert index in indexes, "This expected index should be in the indexes in DB"

--- a/tests/test_tutorial/test_fastapi/test_read_one/test_tutorial001.py
+++ b/tests/test_tutorial/test_fastapi/test_read_one/test_tutorial001.py
@@ -3,7 +3,7 @@ from sqlmodel import create_engine
 from sqlmodel.pool import StaticPool
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/heroes/": {
@@ -113,7 +113,10 @@ openapi_schema = {
                 "properties": {
                     "name": {"title": "Name", "type": "string"},
                     "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                 },
             },
             "HeroRead": {
@@ -123,7 +126,10 @@ openapi_schema = {
                 "properties": {
                     "name": {"title": "Name", "type": "string"},
                     "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                     "id": {"title": "Id", "type": "integer"},
                 },
             },
@@ -135,7 +141,7 @@ openapi_schema = {
                     "loc": {
                         "title": "Location",
                         "type": "array",
-                        "items": {"type": "string"},
+                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
                     },
                     "msg": {"title": "Message", "type": "string"},
                     "type": {"title": "Error Type", "type": "string"},
@@ -155,7 +161,6 @@ def test_tutorial(clear_sqlmodel):
     )
 
     with TestClient(mod.app) as client:
-
         hero1_data = {"name": "Deadpond", "secret_name": "Dive Wilson"}
         hero2_data = {
             "name": "Spider-Boy",

--- a/tests/test_tutorial/test_fastapi/test_relationships/test_tutorial001.py
+++ b/tests/test_tutorial/test_fastapi/test_relationships/test_tutorial001.py
@@ -3,7 +3,7 @@ from sqlmodel import create_engine
 from sqlmodel.pool import StaticPool
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/heroes/": {
@@ -397,8 +397,14 @@ openapi_schema = {
                 "properties": {
                     "name": {"title": "Name", "type": "string"},
                     "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
-                    "team_id": {"title": "Team Id", "type": "integer"},
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
+                    "team_id": {
+                        "title": "Team Id",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                 },
             },
             "HeroRead": {
@@ -408,8 +414,14 @@ openapi_schema = {
                 "properties": {
                     "name": {"title": "Name", "type": "string"},
                     "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
-                    "team_id": {"title": "Team Id", "type": "integer"},
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
+                    "team_id": {
+                        "title": "Team Id",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                     "id": {"title": "Id", "type": "integer"},
                 },
             },
@@ -420,20 +432,43 @@ openapi_schema = {
                 "properties": {
                     "name": {"title": "Name", "type": "string"},
                     "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
-                    "team_id": {"title": "Team Id", "type": "integer"},
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
+                    "team_id": {
+                        "title": "Team Id",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                     "id": {"title": "Id", "type": "integer"},
-                    "team": {"$ref": "#/components/schemas/TeamRead"},
+                    "team": {
+                        "anyOf": [
+                            {"$ref": "#/components/schemas/TeamRead"},
+                            {"type": "null"},
+                        ]
+                    },
                 },
             },
             "HeroUpdate": {
                 "title": "HeroUpdate",
                 "type": "object",
                 "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
-                    "team_id": {"title": "Team Id", "type": "integer"},
+                    "name": {
+                        "title": "Name",
+                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                    },
+                    "secret_name": {
+                        "title": "Secret Name",
+                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                    },
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
+                    "team_id": {
+                        "title": "Team Id",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                 },
             },
             "TeamCreate": {
@@ -475,9 +510,18 @@ openapi_schema = {
                 "title": "TeamUpdate",
                 "type": "object",
                 "properties": {
-                    "id": {"title": "Id", "type": "integer"},
-                    "name": {"title": "Name", "type": "string"},
-                    "headquarters": {"title": "Headquarters", "type": "string"},
+                    "id": {
+                        "title": "Id",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
+                    "name": {
+                        "title": "Name",
+                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                    },
+                    "headquarters": {
+                        "title": "Headquarters",
+                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                    },
                 },
             },
             "ValidationError": {
@@ -488,7 +532,7 @@ openapi_schema = {
                     "loc": {
                         "title": "Location",
                         "type": "array",
-                        "items": {"type": "string"},
+                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
                     },
                     "msg": {"title": "Message", "type": "string"},
                     "type": {"title": "Error Type", "type": "string"},

--- a/tests/test_tutorial/test_fastapi/test_response_model/test_tutorial001.py
+++ b/tests/test_tutorial/test_fastapi/test_response_model/test_tutorial001.py
@@ -3,7 +3,7 @@ from sqlmodel import create_engine
 from sqlmodel.pool import StaticPool
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/heroes/": {
@@ -74,13 +74,18 @@ openapi_schema = {
             },
             "Hero": {
                 "title": "Hero",
-                "required": ["name", "secret_name"],
                 "type": "object",
                 "properties": {
-                    "id": {"title": "Id", "type": "integer"},
+                    "id": {
+                        "title": "Id",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                     "name": {"title": "Name", "type": "string"},
                     "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                 },
             },
             "ValidationError": {
@@ -91,7 +96,9 @@ openapi_schema = {
                     "loc": {
                         "title": "Location",
                         "type": "array",
-                        "items": {"type": "string"},
+                        "items": {
+                            "anyOf": [{"type": "string"}, {"type": "integer"}],
+                        },
                     },
                     "msg": {"title": "Message", "type": "string"},
                     "type": {"title": "Error Type", "type": "string"},
@@ -111,7 +118,6 @@ def test_tutorial(clear_sqlmodel):
     )
 
     with TestClient(mod.app) as client:
-
         hero_data = {"name": "Deadpond", "secret_name": "Dive Wilson"}
         response = client.post("/heroes/", json=hero_data)
         data = response.json()

--- a/tests/test_tutorial/test_fastapi/test_session_with_dependency/test_tutorial001.py
+++ b/tests/test_tutorial/test_fastapi/test_session_with_dependency/test_tutorial001.py
@@ -3,7 +3,7 @@ from sqlmodel import create_engine
 from sqlmodel.pool import StaticPool
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/heroes/": {
@@ -210,7 +210,10 @@ openapi_schema = {
                 "properties": {
                     "name": {"title": "Name", "type": "string"},
                     "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                 },
             },
             "HeroRead": {
@@ -220,7 +223,10 @@ openapi_schema = {
                 "properties": {
                     "name": {"title": "Name", "type": "string"},
                     "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                     "id": {"title": "Id", "type": "integer"},
                 },
             },
@@ -228,9 +234,18 @@ openapi_schema = {
                 "title": "HeroUpdate",
                 "type": "object",
                 "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
+                    "name": {
+                        "title": "Name",
+                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                    },
+                    "secret_name": {
+                        "title": "Secret Name",
+                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                    },
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                 },
             },
             "ValidationError": {
@@ -241,7 +256,9 @@ openapi_schema = {
                     "loc": {
                         "title": "Location",
                         "type": "array",
-                        "items": {"type": "string"},
+                        "items": {
+                            "anyOf": [{"type": "string"}, {"type": "integer"}],
+                        },
                     },
                     "msg": {"title": "Message", "type": "string"},
                     "type": {"title": "Error Type", "type": "string"},
@@ -261,7 +278,6 @@ def test_tutorial(clear_sqlmodel):
     )
 
     with TestClient(mod.app) as client:
-
         hero1_data = {"name": "Deadpond", "secret_name": "Dive Wilson"}
         hero2_data = {
             "name": "Spider-Boy",

--- a/tests/test_tutorial/test_fastapi/test_simple_hero_api/test_tutorial001.py
+++ b/tests/test_tutorial/test_fastapi/test_simple_hero_api/test_tutorial001.py
@@ -3,7 +3,7 @@ from sqlmodel import create_engine
 from sqlmodel.pool import StaticPool
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/heroes/": {
@@ -62,13 +62,18 @@ openapi_schema = {
             },
             "Hero": {
                 "title": "Hero",
-                "required": ["name", "secret_name"],
                 "type": "object",
                 "properties": {
-                    "id": {"title": "Id", "type": "integer"},
+                    "id": {
+                        "title": "Id",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                     "name": {"title": "Name", "type": "string"},
                     "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                 },
             },
             "ValidationError": {
@@ -79,7 +84,9 @@ openapi_schema = {
                     "loc": {
                         "title": "Location",
                         "type": "array",
-                        "items": {"type": "string"},
+                        "items": {
+                            "anyOf": [{"type": "string"}, {"type": "integer"}],
+                        },
                     },
                     "msg": {"title": "Message", "type": "string"},
                     "type": {"title": "Error Type", "type": "string"},
@@ -99,7 +106,6 @@ def test_tutorial(clear_sqlmodel):
     )
 
     with TestClient(mod.app) as client:
-
         hero1_data = {"name": "Deadpond", "secret_name": "Dive Wilson"}
         hero2_data = {
             "name": "Spider-Boy",

--- a/tests/test_tutorial/test_fastapi/test_teams/test_tutorial001.py
+++ b/tests/test_tutorial/test_fastapi/test_teams/test_tutorial001.py
@@ -3,7 +3,7 @@ from sqlmodel import create_engine
 from sqlmodel.pool import StaticPool
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/heroes/": {
@@ -393,8 +393,14 @@ openapi_schema = {
                 "properties": {
                     "name": {"title": "Name", "type": "string"},
                     "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
-                    "team_id": {"title": "Team Id", "type": "integer"},
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
+                    "team_id": {
+                        "title": "Team Id",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                 },
             },
             "HeroRead": {
@@ -404,8 +410,14 @@ openapi_schema = {
                 "properties": {
                     "name": {"title": "Name", "type": "string"},
                     "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
-                    "team_id": {"title": "Team Id", "type": "integer"},
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
+                    "team_id": {
+                        "title": "Team Id",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                     "id": {"title": "Id", "type": "integer"},
                 },
             },
@@ -413,10 +425,22 @@ openapi_schema = {
                 "title": "HeroUpdate",
                 "type": "object",
                 "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
-                    "team_id": {"title": "Team Id", "type": "integer"},
+                    "name": {
+                        "title": "Name",
+                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                    },
+                    "secret_name": {
+                        "title": "Secret Name",
+                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                    },
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
+                    "team_id": {
+                        "title": "Team Id",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                 },
             },
             "TeamCreate": {
@@ -442,8 +466,14 @@ openapi_schema = {
                 "title": "TeamUpdate",
                 "type": "object",
                 "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "headquarters": {"title": "Headquarters", "type": "string"},
+                    "name": {
+                        "title": "Name",
+                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                    },
+                    "headquarters": {
+                        "title": "Headquarters",
+                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                    },
                 },
             },
             "ValidationError": {
@@ -454,7 +484,9 @@ openapi_schema = {
                     "loc": {
                         "title": "Location",
                         "type": "array",
-                        "items": {"type": "string"},
+                        "items": {
+                            "anyOf": [{"type": "string"}, {"type": "integer"}],
+                        },
                     },
                     "msg": {"title": "Message", "type": "string"},
                     "type": {"title": "Error Type", "type": "string"},
@@ -474,7 +506,6 @@ def test_tutorial(clear_sqlmodel):
     )
 
     with TestClient(mod.app) as client:
-
         hero1_data = {"name": "Deadpond", "secret_name": "Dive Wilson"}
         hero2_data = {
             "name": "Spider-Boy",

--- a/tests/test_tutorial/test_fastapi/test_update/test_tutorial001.py
+++ b/tests/test_tutorial/test_fastapi/test_update/test_tutorial001.py
@@ -3,7 +3,7 @@ from sqlmodel import create_engine
 from sqlmodel.pool import StaticPool
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/heroes/": {
@@ -182,7 +182,10 @@ openapi_schema = {
                 "properties": {
                     "name": {"title": "Name", "type": "string"},
                     "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                 },
             },
             "HeroRead": {
@@ -192,7 +195,10 @@ openapi_schema = {
                 "properties": {
                     "name": {"title": "Name", "type": "string"},
                     "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                     "id": {"title": "Id", "type": "integer"},
                 },
             },
@@ -200,9 +206,18 @@ openapi_schema = {
                 "title": "HeroUpdate",
                 "type": "object",
                 "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "secret_name": {"title": "Secret Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
+                    "name": {
+                        "title": "Name",
+                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                    },
+                    "secret_name": {
+                        "title": "Secret Name",
+                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                    },
+                    "age": {
+                        "title": "Age",
+                        "anyOf": [{"type": "integer"}, {"type": "null"}],
+                    },
                 },
             },
             "ValidationError": {
@@ -213,7 +228,9 @@ openapi_schema = {
                     "loc": {
                         "title": "Location",
                         "type": "array",
-                        "items": {"type": "string"},
+                        "items": {
+                            "anyOf": [{"type": "string"}, {"type": "integer"}],
+                        },
                     },
                     "msg": {"title": "Message", "type": "string"},
                     "type": {"title": "Error Type", "type": "string"},
@@ -233,7 +250,6 @@ def test_tutorial(clear_sqlmodel):
     )
 
     with TestClient(mod.app) as client:
-
         hero1_data = {"name": "Deadpond", "secret_name": "Dive Wilson"}
         hero2_data = {
             "name": "Spider-Boy",

--- a/tests/test_tutorial/test_indexes/test_tutorial001.py
+++ b/tests/test_tutorial/test_indexes/test_tutorial001.py
@@ -25,8 +25,8 @@ def test_tutorial(clear_sqlmodel):
     insp: Inspector = inspect(mod.engine)
     indexes = insp.get_indexes(str(mod.Hero.__tablename__))
     expected_indexes = [
-        {"name": "ix_hero_name", "column_names": ["name"], "unique": 0},
-        {"name": "ix_hero_age", "column_names": ["age"], "unique": 0},
+        {"name": "ix_hero_name", "column_names": ["name"], "unique": 0, 'dialect_options': {}},
+        {"name": "ix_hero_age", "column_names": ["age"], "unique": 0, 'dialect_options': {}},
     ]
     for index in expected_indexes:
         assert index in indexes, "This expected index should be in the indexes in DB"

--- a/tests/test_tutorial/test_indexes/test_tutorial001.py
+++ b/tests/test_tutorial/test_indexes/test_tutorial001.py
@@ -25,8 +25,18 @@ def test_tutorial(clear_sqlmodel):
     insp: Inspector = inspect(mod.engine)
     indexes = insp.get_indexes(str(mod.Hero.__tablename__))
     expected_indexes = [
-        {"name": "ix_hero_name", "column_names": ["name"], "unique": 0, 'dialect_options': {}},
-        {"name": "ix_hero_age", "column_names": ["age"], "unique": 0, 'dialect_options': {}},
+        {
+            "name": "ix_hero_name",
+            "column_names": ["name"],
+            "unique": 0,
+            "dialect_options": {},
+        },
+        {
+            "name": "ix_hero_age",
+            "column_names": ["age"],
+            "unique": 0,
+            "dialect_options": {},
+        },
     ]
     for index in expected_indexes:
         assert index in indexes, "This expected index should be in the indexes in DB"

--- a/tests/test_tutorial/test_indexes/test_tutorial006.py
+++ b/tests/test_tutorial/test_indexes/test_tutorial006.py
@@ -26,8 +26,18 @@ def test_tutorial(clear_sqlmodel):
     insp: Inspector = inspect(mod.engine)
     indexes = insp.get_indexes(str(mod.Hero.__tablename__))
     expected_indexes = [
-        {"name": "ix_hero_name", "column_names": ["name"], "unique": 0, 'dialect_options': {}},
-        {"name": "ix_hero_age", "column_names": ["age"], "unique": 0, 'dialect_options': {}},
+        {
+            "name": "ix_hero_name",
+            "column_names": ["name"],
+            "unique": 0,
+            "dialect_options": {},
+        },
+        {
+            "name": "ix_hero_age",
+            "column_names": ["age"],
+            "unique": 0,
+            "dialect_options": {},
+        },
     ]
     for index in expected_indexes:
         assert index in indexes, "This expected index should be in the indexes in DB"

--- a/tests/test_tutorial/test_indexes/test_tutorial006.py
+++ b/tests/test_tutorial/test_indexes/test_tutorial006.py
@@ -26,8 +26,8 @@ def test_tutorial(clear_sqlmodel):
     insp: Inspector = inspect(mod.engine)
     indexes = insp.get_indexes(str(mod.Hero.__tablename__))
     expected_indexes = [
-        {"name": "ix_hero_name", "column_names": ["name"], "unique": 0},
-        {"name": "ix_hero_age", "column_names": ["age"], "unique": 0},
+        {"name": "ix_hero_name", "column_names": ["name"], "unique": 0, 'dialect_options': {}},
+        {"name": "ix_hero_age", "column_names": ["age"], "unique": 0, 'dialect_options': {}},
     ]
     for index in expected_indexes:
         assert index in indexes, "This expected index should be in the indexes in DB"

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 import pytest
-from pydantic import validator
+from pydantic import field_validator
 from pydantic.error_wrappers import ValidationError
 from sqlmodel import SQLModel
 
@@ -22,12 +22,12 @@ def test_validation(clear_sqlmodel):
         secret_name: Optional[str] = None
         age: Optional[int] = None
 
-        @validator("name", "secret_name", "age")
+        @field_validator("name", "secret_name", "age")
         def reject_none(cls, v):
             assert v is not None
             return v
 
-    Hero.validate({"age": 25})
+    Hero.model_validate({"age": 25})
 
     with pytest.raises(ValidationError):
-        Hero.validate({"name": None, "age": 25})
+        Hero.model_validate({"name": None, "age": 25})


### PR DESCRIPTION
This change allows the use of mixins (e.g., `AwaitableAttrs`) that do not have a `model_config`