### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,8 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.7"
-SQLAlchemy = ">=1.4.36,<2.0.0"
-pydantic = "^1.9.0"
+SQLAlchemy = ">=2.0.0,<2.1.0"
+pydantic = ">=2.1.1,<=2.4.2"
 sqlalchemy2-stubs = {version = "*", allow-prereleases = true}
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
tiangolo/sqlmodel main branch now uses sqlalchemy ^2.x.x based on [his roadmap](https://github.com/tiangolo/sqlmodel/issues/654). This change aligns both sqlalchemy and pydantic dependencies back to a working version. 